### PR TITLE
0.9.99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Since Warden Supreme is an evolution of WARDEN and continues to maintain and pub
 dedicated artefacts,
 this changelog also includes the original WARDEN changelog.
 
-## NEXT
+## 0.9.99
 
 This release introduces breaking changes to the integrated ("Supreme") components to deliver **truly, fully integrated
 key and app attestation**, pinning down the last unnecessarily moving parts:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx8G
 
-artifactVersion=0.9.99-SNAPSHOT
+artifactVersion=0.9.99
 groupId=at.asitplus.warden
 
 jdk.version=17


### PR DESCRIPTION
This release introduces breaking changes to the integrated ("Supreme") components to deliver **truly, fully integrated
key and app attestation**, pinning down the last unnecessarily moving parts:

* Rename `AttestationValidator` -> `AttestationVerifier` to align with wording (and introduce typealias, but marked as deprecated)
* Rename `verifyKeyAttestation` -> `verifyAttestation` (and introduce delegate, but marked as deprecated)
    * `CertificateIssuer` now has `AttestationResult.Verified` as receiver for the new function.
    * The deprecated function stays as it is.
* Allow `CertificateIssuer` to throw instead of returning a `KmmResult`
* Constrain challenge issuing wrt. validity duration: No more params can be specified, but informational adding of time zone is still allowed.

**It also includes behavioural changes to the Android and iOS attestation defaults:**

* Don't allow negative validity durations
* Ignore Android leaf cert validity by default, because Warden Supreme, by default, uses random cryptographic nonces.
    * `ingoreLeafValidity()` (yes, with typo!) function of the `AndroidAttestationConfiguration.Builder` is now a deprecated NOOP to be removed.
    * `enforceLeafValidity()` (without typo!) function was introduced
* Android `attestationStatementValiditySeconds` defaults to `null`, because Warden Supreme, by default, uses random cryptographic nonces.
* iOS clock verification time offset defaults to five minutes, which are added to the attestation statement validity by default.
* Rename `Warden` -> `Makoto` to more clearly distinguish individual components by name
    * A `typealias Warden = Makoto` is present, but marked as deprecated
* Rename `AndroidAttestationChecker` -> `Roboto` to more clearly distinguish individual components by name
    * Rename `HardwareAttestationChecker` -> `HardwareAttestationVerifier` (and introduce typealias, but marked as deprecated) 
    * Rename `NougatHybridAttestationChecker` -> `NougatHybridAttestationVerifier` (and introduce typealias, but marked as deprecated) 
    * Rename `SoftwareAttestationChecker` -> `SoftwareAttestationVerifier` (and introduce typealias, but marked as deprecated)
* Android total validity offset is now more lenient and simply checked for overflows
* **If all parameters are configured explicitly, nothing changes, except for some renames**

**New features:**

* Ship a default OID to identify the attestation proof.
* Add defaults for keyConstraints and nonce validity duration &rarr; Fully integrated key and attestation generation
* Transmit device names inside CSR on a best-effort basis
* Per-App StrongboxOverride
* Expose Makoto `verificationTimeOffset` and `clock`, `shortestValidityDuration`
* Rework Trust Anchor Management:
    * Introduce `TrustedRoot` interface to represent trust anchors
        * `TrustedRoot.Certificate` for certificates
        * `TrustedRoot.PublicKey` for using raw public keys, optionally specifying a CA name
            * No CA name -> no CA name check
            * CA name set -> CA name check
    * Android trust anchors can now be certificates or public keys thanks to `TrustedRoot`
        * Default hardware attestation trust anchors are available in `GOOGLE_DEFAULT_HARDWARE_TRUST_ANCHORS`
        * Default software attestation trust anchors for Android <=11 are available in
          `GOOGLE_SOFTWARE_TRUST_ANCHORS_UNTIL_A11`
    * iOS now also supports setting custom trust anchors (currently certificates only) via
        * `trustedRoots` config property
        * `trustedRootOverrides` for app-specific overrides
        * `overrideTrustedRoots` for the builder
        * Defaults trusted roots are available in `APPLE_DEFAULT_TRUSTED_ROOTS`
    * Default android trust anchors are now all the attestation certificates, not just a raw public key
    * Existing function signatures and constants are preserved for compatibility **but will be removed in the next major
      release**
    * Android configuration migration guide (iOS only got added functionality):
        * `hardwareAttestationTrustAnchors` -> `hardwareTrustedRoots`
        * `softwareAttestationTrustAnchors` -> `softwareTrustedRoots`
        * `AppData.overrideTrustAnchors` -> `AppData.trustedRootOverrides`
        * `AppData.trustAnchorOverrides` -> `AppData.trustedRootOverrides`
        * `AppData.signatureDigests` -> `AppData.signerFingerprints`
* Consistent configuration Builder API functions
    * `overrideXXX(s)` -> `XXXoverride(s)`