### PR TITLE
0.9.9999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Since Warden Supreme is an evolution of WARDEN and continues to maintain and pub
 dedicated artefacts,
 this changelog also includes the original WARDEN changelog.
 
-## 1.0.0-SNAPSHOT
+## 0.9.9999
 * Fix infinite recursion on clock conversion
 * Integration tests with default validity periods
-* Fix wrong offset sign with secondary constructor
+* Fix wrong offset sign with secondary `AttestationVerifier` constructor
 * Rework NOOP attestation and NOOP results
     * Non-error AttestationResults now come with an `AttestationResult.Kind` marker interface
     * Makoto produces `AttestationResult.Verified`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx8G
 
-artifactVersion=1.0.0-SNAPSHOT
+artifactVersion=0.9.9999
 groupId=at.asitplus.warden
 
 jdk.version=17


### PR DESCRIPTION
* Fix infinite recursion on clock conversion
* Integration tests with default validity periods
* Fix wrong offset sign with secondary `AttestationVerifier` constructor
* Rework NOOP attestation and NOOP results
    * Non-error AttestationResults now come with an `AttestationResult.Kind` marker interface
    * Makoto produces `AttestationResult.Verified`
    * NoopAttestationService produces `AttestationResult.NOOP`
    * `KeyAttestation.fold` now produces a nullable `AttestationResult.Verified` on success to acccount for NOOP results
    * Makoto and NoopAttestationService bring their own `foldTyped` extenstion (which sadly cannot override a common abstract extension, because they need to be inline)
* Make `makoto` property of `AttestationVerifier` public
* Versioned debug statements