### PR TITLE
1.0.0-RC10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,11 @@ jobs:
         run: |
           export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
           ./gradlew mkDocsSite
+        env:
+          SIGN_LOCAL_REPO_ARTEFACTS: 'true'
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PUBLISH_SIGNING_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PUBLISH_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PUBLISH_SIGNING_PASSWORD }}
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ dedicated artefacts,
 this changelog also includes the original WARDEN changelog.
 
 
-# NEXT
-* Android: Prefer hex encoding of signer fingerprints over base64Url (use 64 characters length as a threshold plus checks for `:` and whitespace to discriminate)
+# 1.0.0-RC10
+* Android:
+    * Fix `AuthorizationList` parser bug
+    * Canonical configuration now prefers hex encoding of signer fingerprints over base64Url (use 64 characters length as a threshold plus checks for `:` and whitespace to discriminate)
 
 # 1.0.0-RC9
 * Relax Spring and Hoplite parsing (property names / keys can now be snake_case (upper and lower) and kebap-case as well)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx8G
 
-artifactVersion=1.0.0-SNAPSHOT
+artifactVersion=1.0.0-RC10
 groupId=at.asitplus.warden
 
 jdk.version=17

--- a/supreme/common/src/commonMain/kotlin/parser/AuthorizationList.kt
+++ b/supreme/common/src/commonMain/kotlin/parser/AuthorizationList.kt
@@ -2367,8 +2367,8 @@ data class AuthorizationList private constructor(
      *
      * For a detailed definition of the `Modules` and `Module` structures, as well as the computation of `moduleHash`, you can refer to the Android Open Source Project's documentation on Keymaster's attestation process.
      */
-    data class ModuleHash(val sha256Digest: ByteArray) : Asn1Encodable<Asn1Primitive>,
-        Tagged.WithTag<Asn1Primitive> {
+    data class ModuleHash(val sha256Digest: ByteArray) : Asn1Encodable<Asn1Element>,
+        Tagged.WithTag<Asn1Element> {
         override fun encodeToTlv() = Asn1.OctetString(sha256Digest)
 
         @OptIn(ExperimentalStdlibApi::class)
@@ -2376,8 +2376,8 @@ data class AuthorizationList private constructor(
             return "ModuleHash(sha256Digest=${sha256Digest.toHexString()})"
         }
 
-        companion object Tag : Tagged(724uL), Asn1Decodable<Asn1Primitive, ModuleHash> {
-            override fun doDecode(src: Asn1Primitive) = ModuleHash(src.asOctetString().content)
+        companion object Tag : Tagged(724uL), Asn1Decodable<Asn1Element, ModuleHash> {
+            override fun doDecode(src: Asn1Element) = ModuleHash(src.asOctetString().content)
         }
 
         override val tagged get() = Tag


### PR DESCRIPTION
* Android:
    * Fix `AuthorizationList` parser bug
    * Canonical configuration now prefers hex encoding of signer fingerprints over base64Url (use 64 characters length as a threshold plus checks for `:` and whitespace to discriminate)