### PR TITLE
bound in-memory challenge cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ this changelog also includes the original WARDEN changelog.
 
 # NEXT
 
+* Security hardening:
+    * Bound the default `InMemoryChallengeCache` used by `AttestationVerifier` to `100_000` in-flight challenges.
+    * Add `InMemoryChallengeCache.ChallengeCacheFullException` for cache-overflow handling; callers should map this to back-end rate limiting / HTTP `429 Too Many Requests` as appropriate.
+    * Allow duplicate nonce overwrites and prune expired entries before enforcing the in-memory challenge limit.
+
 # 1.0.0-RC10
 
 * Update to latest Google upstream attestation library (`a83ff03aa1c1c03ab5090bfcdc352aa8ff5eeb60`)

--- a/docs/docs/integration/datamodel.md
+++ b/docs/docs/integration/datamodel.md
@@ -29,7 +29,7 @@ to respond.
 - `issuedAt`: when the challenge was issued.
 - `validity`: how long the challenge is valid.
 - `timeZone`: optional server time zone (informational).
-- `nonce`: server-chosen nonce (≤128 bytes).
+- `nonce`: server-chosen nonce (≤128 bytes). This is sensitive replay-protection material. Treat it as a short-lived bearer value: do not log it, do not expose it across sessions or callers, and serve challenges only over protected transport.
 - `attestationEndpoint`: where the client submits the attestation proof.
 - `proofOID`: CSR attribute identifier used to carry the attestation statement payload.
 - `genericDeviceNameOID`: whether to include a generic make/model (not user-assignable name) in the CSR.

--- a/docs/docs/integration/supreme.md
+++ b/docs/docs/integration/supreme.md
@@ -219,8 +219,12 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
 
 ??? info inline end "Important Nonce Info"
     Under the hood, the attestation verifier needs a source to generate attestation challenges, track them, invalidate them, and match them against incoming attestation requests.
-    Warden Supreme provides a secure nonce generation service and uses an in-memory challenge cache by default, which is fine for small to medium loads but not for larger production deployments.
-    In such scenarios, roll your own (backed by Redis, for example).
+    Warden Supreme provides a secure nonce generation service and uses a bounded in-memory challenge cache by default.
+    The default cache allows up to `100_000` unexpired in-flight challenges per verifier instance. Once full, it prunes expired entries and then throws `InMemoryChallengeCache.ChallengeCacheFullException` instead of evicting active challenges.
+    Challenge nonces are sensitive replay-protection material. Treat them as bearer values for their short lifetime: do not log them, do not expose them across sessions or callers, serve them only over protected transport, and bind/rate-limit callers in your HTTP layer when your service needs that context.
+    Map that exception at your HTTP layer to `429 Too Many Requests` and, if useful, a `Retry-After` header.
+    The cache deliberately does not implement backoff; caller-aware rate limiting needs IP, account, tenant, or device context and should live outside Warden Supreme.
+    For horizontally scaled or high-volume deployments, use a distributed TTL-backed `ChallengeValidator` instead (Redis, for example).
 
 ```kotlin
 --8<-- "Readme-Verifier-min.kt:3"
@@ -243,7 +247,7 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
         * Usable for 30 seconds without reauthentication
         * Enrolling new biometric factors will invalidate the key
     5. We want extra long nonces (default: 64 bytes; max: 128 bytes).
-    6. Checking and invalidating challenges is handled by a Redis-backed cache (not shown here; roll your own).
+    6. Checking and invalidating challenges is handled by a Redis-backed cache (not shown here; roll your own). This is the recommended approach when multiple verifier instances issue challenges.
     
 
 Instead of passing parameters programmatically, it is also possible to externalise configuration (see [Externalising Configuration](config.md)).
@@ -255,7 +259,7 @@ attestation policies, as well as everything needed on top (object identifiers, e
 ```
 
 1. Default, secure nonce generator.
-2. Default in-memory challenge validator.
+2. Default bounded in-memory challenge validator.
 
 
 
@@ -274,7 +278,7 @@ This example assumes Ktor. Since this is an example environment, TLS is omitted 
 
 1. We're using JSON to transmit the challenge and the final response.
 2. Endpoint to serve challenges to clients
-3. It does nothing but issue challenges
+3. It does nothing but issue challenges. In production, catch `InMemoryChallengeCache.ChallengeCacheFullException` here and return `429 Too Many Requests`; apply caller-aware rate limiting outside the verifier.
 4. The full URL to post the attestation proof to
 5. Endpoint expecting CSRs containing attestation statement payloads
 6. Read the raw CSR from the HTTP body

--- a/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
@@ -103,8 +103,14 @@ constructor(
      *
      * **Note that the [challengeValidator] needs to account for this inverse view! The default [InMemoryChallengeCache] already does that.**
      *
+     * The issued challenge nonce is sensitive replay-protection material. Treat it as a bearer value for the lifetime of
+     * the challenge: do not log it, do not expose it across sessions or callers, serve it only over protected transport,
+     * and keep caller/session binding and rate limiting in the surrounding HTTP layer if your service needs it.
      *
+     * @throws Throwable For example, [InMemoryChallengeCache.ChallengeCacheFullException] is thrown if the default in-memory cache is full. Custom
+     * [ChallengeValidator] implementations may throw their own operational exceptions from [ChallengeValidator.store].
      */
+    @Throws(Throwable::class)
     suspend fun issueChallenge(
         postEndpoint: String,
         timeZone: TimeZone? = null,
@@ -336,6 +342,9 @@ constructor(
  * Most probably, this will check against a nonce cache and evict any matched nonce from the cache.
  * **Implementing this function in a meaningful manner is absolutely crucial**, since this is the actual challenge
  * matching, ensuring freshness!
+ * Challenge nonces are sensitive replay-protection material: implementations and operators should avoid logging them,
+ * avoid exposing them across sessions or callers, and rely on protected transport plus caller-aware controls outside the
+ * nonce cache when needed.
  *
  * **BEWARE OF CLOCK DRIFT AND CONFIGURED OFFSETS WRT. VALIDITY DURATION!**
  *
@@ -345,7 +354,11 @@ interface ChallengeValidator {
     /**
      * The contract of this function is that it stores challenges regardless of their contents and performs no sanity checks.
      * Reason: Strong cryptographic nonces are assumed, making collisions unrealistic
+     *
+     * Implementations may throw if they cannot store the challenge. For example, [InMemoryChallengeCache] throws
+     * [InMemoryChallengeCache.ChallengeCacheFullException] when its bounded in-memory capacity is exhausted.
      */
+    @Throws(InMemoryChallengeCache.ChallengeCacheFullException::class)
     suspend fun store(challenge: AttestationChallenge)
 
     /**
@@ -402,9 +415,36 @@ sealed class PreAttestationError {
  * Caches issued challenges in memory in a coroutine-safe way. Requires a [clock] and an [offset].
  * The [AttestationVerifier] passes [Makoto]'s clock and the inverse of [Makoto.verificationTimeOffset], since these two values
  * are also encoded into issues challenges.
+ *
+ * The cache is bounded by [maxChallenges] and throws [InMemoryChallengeCache.ChallengeCacheFullException] from [store]
+ * when that many unexpired challenges are already in flight. Expired entries are pruned before the capacity check and a
+ * duplicate nonce overwrites the existing entry even at capacity.
+ *
+ * Production deployments should apply caller-aware rate limiting outside this cache and may prefer a distributed
+ * TTL-backed [ChallengeValidator] when multiple verifier instances are used. The cache deliberately owns no backoff
+ * state, because backoff needs caller identity, IP, account, or device context.
+ *
+ * @throws IllegalArgumentException if [maxChallenges] is not positive.
  */
 //internal props for testing
-class InMemoryChallengeCache(internal val clock: Clock, internal val offset: Duration) : ChallengeValidator {
+class InMemoryChallengeCache
+@Throws(IllegalArgumentException::class)
+constructor(
+    internal val clock: Clock,
+    internal val offset: Duration,
+    val maxChallenges: Int = DEFAULT_MAX_IN_MEMORY_CHALLENGES,
+) : ChallengeValidator {
+
+    companion object {
+        const val DEFAULT_MAX_IN_MEMORY_CHALLENGES: Int = 100_000
+    }
+
+    class ChallengeCacheFullException(val maxChallenges: Int) :
+        IllegalStateException("In-memory challenge cache full: $maxChallenges challenges in flight")
+
+    init {
+        require(maxChallenges > 0) { "maxChallenges must be positive" }
+    }
 
     private val mutex = Mutex()
 
@@ -422,11 +462,16 @@ class InMemoryChallengeCache(internal val clock: Clock, internal val offset: Dur
 
     private val challengesByNonce = mutableMapOf<NonceKey, AttestationChallenge>()
 
+    @Throws(ChallengeCacheFullException::class)
     override suspend fun store(challenge: AttestationChallenge) {
         mutex.withLock {
             pruneExpiredEntries()
+            val key = NonceKey(challenge.nonce)
             // Strong cryptographic nonces make collisions unrealistic, so we simply overwrite
-            challengesByNonce[NonceKey(challenge.nonce)] = challenge
+            if (!challengesByNonce.containsKey(key) && challengesByNonce.size >= maxChallenges) {
+                throw ChallengeCacheFullException(maxChallenges)
+            }
+            challengesByNonce[key] = challenge
         }
     }
 

--- a/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierChallengeTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierChallengeTest.kt
@@ -3,6 +3,7 @@
 package at.asitplus.attestation.supreme
 
 import at.asitplus.testballoon.checkAll
+import at.asitplus.catching
 import at.asitplus.testballoon.invoke
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.withClue
@@ -39,6 +40,27 @@ val AttestationVerifierChallengeTest by testSuite {
             verifier.challengeValidator.validate(csr)
                 .shouldBeInstanceOf<ChallengeValidationResult.Failure>()
         }
+    }
+
+    "issueChallenge propagates challenge cache overflow" {
+        val firstNonce = Random.Default.nextBytes(16)
+        val secondNonce = Random.Default.nextBytes(16)
+        var first = true
+        val verifier = AttestationVerifier(
+            makoto = makoto,
+            nonceGenerator = suspend {
+                if (first) {
+                    first = false
+                    firstNonce
+                } else secondNonce
+            },
+            challengeValidator = InMemoryChallengeCache(fixedClock, -verificationOffset, maxChallenges = 1),
+        )
+
+        verifier.issueChallenge(attestationEndpoint).nonce.contentEquals(firstNonce) shouldBe true
+        catching { verifier.issueChallenge(attestationEndpoint) }.exceptionOrNull()
+            .shouldBeInstanceOf<InMemoryChallengeCache.ChallengeCacheFullException>()
+            .maxChallenges shouldBe 1
     }
 
     "concurrent verification only consumes a challenge once" {

--- a/supreme/verifier/src/jvmTest/kotlin/ChallengeCacheTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/ChallengeCacheTest.kt
@@ -1,6 +1,7 @@
 package at.asitplus.attestation.supreme
 
 import at.asitplus.attestation.FixedTimeClock
+import at.asitplus.catching
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.minus
 import at.asitplus.signum.indispensable.CryptoSignature
@@ -21,6 +22,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import java.util.*
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -43,6 +45,13 @@ private fun csrForChallenge(challenge: AttestationChallenge): Pkcs10Certificatio
 }
 
 val ChallengeVerifierTest by testSuite(testConfig = TestConfig.testScope(isEnabled = true, timeout = 10.minutes)) {
+
+    "maxChallenges must be positive" {
+        val clock = FixedTimeClock(Random.nextLong())
+
+        catching { InMemoryChallengeCache(clock, Duration.ZERO, 0) }.isFailure shouldBe true
+        catching { InMemoryChallengeCache(clock, Duration.ZERO, -1) }.isFailure shouldBe true
+    }
 
     "once" {
         val nonce = Random.nextBytes(16)
@@ -199,6 +208,114 @@ val ChallengeVerifierTest by testSuite(testConfig = TestConfig.testScope(isEnabl
                 result.reason.message?.lowercase() shouldContain "no challenge"
             }
         }
+    }
+
+    "capacity rejects distinct unexpired challenges" {
+        val clock = FixedTimeClock(Random.nextLong())
+        val cache = InMemoryChallengeCache(clock, Duration.ZERO, maxChallenges = 1)
+        val challenge1 = AttestationChallenge(
+            clock.now(),
+            1.seconds,
+            null,
+            Random.nextBytes(16),
+            "",
+            WardenDefaults.OIDs.ATTESTATION_PROOF
+        )
+        val challenge2 = AttestationChallenge(
+            clock.now(),
+            1.seconds,
+            null,
+            Random.nextBytes(16),
+            "",
+            WardenDefaults.OIDs.ATTESTATION_PROOF
+        )
+
+        cache.store(challenge1)
+        catching { cache.store(challenge2) }.exceptionOrNull()
+            .shouldBeInstanceOf<InMemoryChallengeCache.ChallengeCacheFullException>()
+            .maxChallenges shouldBe 1
+        cache.validate(csrForChallenge(challenge1)).shouldBeInstanceOf<ChallengeValidationResult.Success>()
+    }
+
+    "capacity allows duplicate nonce overwrite" {
+        val clock = FixedTimeClock(Random.nextLong())
+        val cache = InMemoryChallengeCache(clock, Duration.ZERO, maxChallenges = 1)
+        val challenge = AttestationChallenge(
+            clock.now(),
+            1.seconds,
+            null,
+            Random.nextBytes(16),
+            "",
+            WardenDefaults.OIDs.ATTESTATION_PROOF
+        )
+
+        cache.store(challenge)
+        cache.store(challenge)
+        cache.validate(csrForChallenge(challenge)).shouldBeInstanceOf<ChallengeValidationResult.Success>()
+        cache.validate(csrForChallenge(challenge)).shouldBeInstanceOf<ChallengeValidationResult.Failure>()
+    }
+
+    "capacity prunes expired challenges before rejecting" {
+        val clock = FixedTimeClock(Random.nextLong())
+        val cache = InMemoryChallengeCache(clock, Duration.ZERO, maxChallenges = 1)
+        val expired = AttestationChallenge(
+            clock.now(),
+            1.seconds,
+            null,
+            Random.nextBytes(16),
+            "",
+            WardenDefaults.OIDs.ATTESTATION_PROOF
+        )
+        val fresh = AttestationChallenge(
+            clock.now() + 2.seconds,
+            1.seconds,
+            null,
+            Random.nextBytes(16),
+            "",
+            WardenDefaults.OIDs.ATTESTATION_PROOF
+        )
+
+        cache.store(expired)
+        clock.offsetBy(2.seconds)
+        cache.store(fresh)
+        cache.validate(csrForChallenge(fresh)).shouldBeInstanceOf<ChallengeValidationResult.Success>()
+        cache.validate(csrForChallenge(expired)).shouldBeInstanceOf<ChallengeValidationResult.Failure>()
+    }
+
+    "concurrent overflow stays bounded" {
+        val attempts = 32
+        val maxChallenges = 5
+        val clock = FixedTimeClock(Random.nextLong())
+        val cache = InMemoryChallengeCache(clock, Duration.ZERO, maxChallenges = maxChallenges)
+        val successes = AtomicInteger(0)
+        val overflows = AtomicInteger(0)
+        val unexpected = AtomicInteger(0)
+        val jobs = Stack<Job>()
+
+        repeat(attempts) {
+            jobs += launch {
+                val challenge = AttestationChallenge(
+                    clock.now(),
+                    1.seconds,
+                    null,
+                    WardenDefaults.nonceGenerator(),
+                    "",
+                    WardenDefaults.OIDs.ATTESTATION_PROOF
+                )
+                catching { cache.store(challenge) }.fold(
+                    onSuccess = { successes.incrementAndGet() },
+                    onFailure = {
+                        if (it is InMemoryChallengeCache.ChallengeCacheFullException) overflows.incrementAndGet()
+                        else unexpected.incrementAndGet()
+                    }
+                )
+            }
+        }
+
+        jobs.joinAll()
+        successes.get() shouldBe maxChallenges
+        overflows.get() shouldBe attempts - maxChallenges
+        unexpected.get() shouldBe 0
     }
 
     "stresstest" - {


### PR DESCRIPTION
* Security hardening:
    * Bound the default `InMemoryChallengeCache` used by `AttestationVerifier` to `100_000` in-flight challenges.
    * Add `InMemoryChallengeCache.ChallengeCacheFullException` for cache-overflow handling; callers should map this to back-end rate limiting / HTTP `429 Too Many Requests` as appropriate.
    * Allow duplicate nonce overwrites and prune expired entries before enforcing the in-memory challenge limit.