### PR TITLE
Feature/hashed PR 3/3 (Build changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ this changelog also includes the original WARDEN changelog.
       a complete CSR or TBS CSR. Hash algorithms remain challenge-owned and are never supplied with client transport.
       Deprecate CSR-only overloads; they reject hash authentication and requested attributes instead of silently changing
       behaviour.
-    * Add ordered required/optional client-provided attributes using `AttestableAttributes`, `ToBeAttestedAttribute`,
-      `PrimitiveType`, and ASN.1 codecs. Values are authenticated by either supported mode.
+    * Add ordered required/optional client-provided attributes using `toBeAttestedAttributes`.
+      Values are authenticated by either supported mode.
     * Move authentication selection from optional `KeyConstraints` into `AttestationChallenge`.
     * Add canonical `AttestationHashInput` conversion to and from TBS CSR data, excluding only the public key and exactly
       one attestation-proof attribute.
@@ -24,7 +24,7 @@ this changelog also includes the original WARDEN changelog.
       non-canonical attribute order, key mismatches, and missing or invalid requested attributes.
     * Route all new verifier validation failures through `onPreAttestationError` as typed
       `PreAttestationError.ClientDataValidation` values.
-    * Add `dataAuthentication` and human-readable `attestableAttributes` support to `SupremeConfiguration` JSON/YAML.
+    * Add `dataAuthentication` and human-readable `toBeAttestedAttributes` support to `SupremeConfiguration` JSON/YAML.
     * Expand client, verifier, property, and Android-emulator end-to-end coverage for both authentication modes and
       required/optional attribute combinations.
 * Add Supreme dependency to `supreme-common`

--- a/docs/docs/integration/config.md
+++ b/docs/docs/integration/config.md
@@ -139,7 +139,7 @@ Two integrated-flow properties control proof authentication and client-provided 
 * `dataAuthentication` defaults to signature mode. Use `{ "type": "SIGNATURE" }` for a signed CSR with proof of
   possession, or `{ "type": "HASH", "algorithm": "SHA256" }` for an unsigned TBS CSR whose canonical hash input is
   bound through the platform attestation nonce.
-* `attestableAttributes` is optional. It defines the dedicated CSR attribute OID and an ordered list of values. `type`
+* `toBeAttestedAttributes` is optional. It defines the dedicated CSR attribute OID and an ordered list of values. `type`
   uses readable `PrimitiveType` names (`STRING`, `INT`, `BOOLEAN`, `BYTEARRAY`, etc.); `required` defaults to `true`.
 
 The generated YAML and JSON examples below demonstrate hash authentication together with one required and one optional

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 
 ## do not track latest and greatest for better downstream compat
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 
 guava = "33.5.0-jre"
 autovalue = "1.11.0"
 signum = "3.24.0"
 supreme = "0.15.0"
-agp = "8.13.2"
+agp = "9.1.1"
 cbor = "0.9"
 gson = "2.13.2"
 errorprone = "2.43.0"
@@ -26,9 +26,9 @@ semver = "1.2.0"
 serialization ="1.11.0"
 
 slf4j = "1.7.36"
-testballoon = "1.0.0-K2.4.0"
+testballoon = "1.0.1-K2.4.0"
 #testballoonAddons = "0.14.0"
-asp = "20260701"
+asp = "20260722"
 sbombastic ="0.0.3"
 pitest = "1.19.0-rc.3"
 pitest-junit5 = "1.2.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/supreme/client/src/commonTest/kotlin/AttestationClientProofTest.kt
+++ b/supreme/client/src/commonTest/kotlin/AttestationClientProofTest.kt
@@ -38,7 +38,7 @@ private fun clientChallenge(
     proofOID = WardenDefaults.OIDs.ATTESTATION_PROOF,
     genericDeviceNameOID = null,
     keyConstraints = WardenDefaults.KeyConstraints.p256Signer,
-    attestableAttributes = attributes,
+    toBeAttestedAttributes = attributes,
     dataAuth = authentication,
 )
 

--- a/supreme/common/src/commonMain/kotlin/AttestationChallenge.kt
+++ b/supreme/common/src/commonMain/kotlin/AttestationChallenge.kt
@@ -175,7 +175,7 @@ private constructor(
      *  @param keyConstraints Specifies key constraints for the client.
      *  @param additionalPayload Optional user-defined payload. See [additionalPayload] for serialization requirements.
      *  @param transientData Optional runtime-only attachment. Not serialized and excluded from equality/hashing.
-     *  @param attestableAttributes Optional ordered client-provided values to bind to the attestation.
+     *  @param toBeAttestedAttributes Optional ordered client-provided values to bind to the attestation.
      *  @param dataAuth Authentication mode for the TBS CSR contents.
      *
      * @throws IllegalArgumentException in case the [nonce] is larger than 128 bytes or shorter than 4 bytes
@@ -192,7 +192,7 @@ private constructor(
         keyConstraints: KeyConstraints? = null,
         additionalPayload: Map<String, Constrained>? = null,
         transientData: Any? = null,
-        attestableAttributes: CertificationRequestAttributeAttestationDescriptor? = null,
+        toBeAttestedAttributes: CertificationRequestAttributeAttestationDescriptor? = null,
         dataAuth: DataAuthentication = DataAuthentication.Signature,
     ) : this(
         issuedAt = issuedAt,
@@ -206,7 +206,7 @@ private constructor(
         keyConstraints = keyConstraints,
         additionalPayload = additionalPayload,
         transientData = transientData,
-        toBeAttestedAttributes = attestableAttributes,
+        toBeAttestedAttributes = toBeAttestedAttributes,
         dataAuth = dataAuth,
     )
 
@@ -274,7 +274,8 @@ private constructor(
         val attributes: List<AttributeAttestationDescriptor>
     ) {
         init {
-            if(attributes.isEmpty()) throw IllegalArgumentException("attributes can't be empty!")
+            require(attributes.isNotEmpty()) { "attributes can't be empty!" }
+            require(attributes.size == attributes.distinctBy { it.name }.size) { "attributes names must be distinct!" }
         }
     }
 

--- a/supreme/common/src/commonMain/kotlin/DataAuthentication.kt
+++ b/supreme/common/src/commonMain/kotlin/DataAuthentication.kt
@@ -64,7 +64,6 @@ sealed interface DataAuthentication {
             when (it.type) {
                 SerializedDataAuthentication.Type.SIGNATURE-> Signature
                 SerializedDataAuthentication.Type.HASH -> Hash(requireNotNull(it.algorithm) { "Missing DataAuthentication.algorithm" })
-                else -> error("Unknown DataAuthentication type: ${it.type}")
             }
         }
     }

--- a/supreme/common/src/jvmTest/kotlin/CertificationRequestAttestationTest.kt
+++ b/supreme/common/src/jvmTest/kotlin/CertificationRequestAttestationTest.kt
@@ -151,7 +151,7 @@ val CertificationRequestAttestationTest by matrixSuite {
             nonce = byteArrayOf(1, 2, 3, 4),
             attestationEndpoint = "https://example.invalid/attest",
             proofOID = proofOid,
-            attestableAttributes = requested,
+            toBeAttestedAttributes = requested,
         )
         val attribute = Pkcs10CertificationRequestAttribute(
             attributeOid,

--- a/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
@@ -37,7 +37,7 @@ private val extensionRequestOid = ObjectIdentifier("1.2.840.113549.1.9.14")
  * [attestationProofOID] identifies the TBS CSR attribute carrying the attestation statement. It defaults to
  * [WardenDefaults.OIDs.ATTESTATION_PROOF]. [dataAuth] selects the default authentication mode for issued challenges:
  * signed PKCS#10 with proof of possession, or hash-bound unsigned TBS CSR without proof of possession.
- * [attestableAttributes] optionally requests ordered client-provided values which are encoded into the TBS CSR and
+ * [toBeAttestedAttributes] optionally requests ordered client-provided values which are encoded into the TBS CSR and
  * authenticated by the selected mode.
  * When [defaultKeyConstraints] is specified, all issued challenges will automatically convey this, unless overridden.
  * **Note that key constraints cannot be reliably enforced** due to technical client limitations. Not all platforms can restrict key usage and properties!
@@ -65,7 +65,7 @@ constructor(
     val defaultKeyConstraints: KeyConstraints? = WardenDefaults.KeyConstraints.p256Signer,
     val nonceValidity: Duration = makoto.longestValidityDuration
         ?: IosAttestationConfiguration.DEFAULT_VALIDITY_SECONDS.seconds,
-    val attestableAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+    val toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
     val dataAuth: DataAuthentication = DataAuthentication.Signature,
     private val nonceGenerator: NonceGenerator = WardenDefaults.nonceGenerator,
     /*internal for testing*/
@@ -93,7 +93,7 @@ constructor(
             iosAttestationConfiguration.attestationStatementValiditySeconds,
             androidAttestationConfiguration.attestationStatementValiditySeconds
         ),
-        attestableAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+        toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
         dataAuth: DataAuthentication = DataAuthentication.Signature,
         nonceGenerator: NonceGenerator = suspend { CryptoRand.nextBytes(ByteArray(64)) },
         challengeValidator: ChallengeValidator = InMemoryChallengeCache(clock, -verificationTimeOffset),
@@ -103,7 +103,7 @@ constructor(
         genericDeviceNameOID,
         defaultKeyConstraints,
         nonceValidity,
-        attestableAttributes,
+        toBeAttestedAttributes,
         dataAuth,
         nonceGenerator,
         challengeValidator,
@@ -116,7 +116,7 @@ constructor(
      * It is possible, to pass a [timeZone], but this is purely informational and is not fed into validity checks.
      *
      * Specify [keyConstraints] to communicate to the type of key and its properties to the client, for automatic key creation. Defaults to [defaultKeyConstraints].
-     * [attestableAttributes] requests ordered client-provided values; [dataAuth] determines how the resulting TBS CSR is
+     * [toBeAttestedAttributes] requests ordered client-provided values; [dataAuth] determines how the resulting TBS CSR is
      * authenticated. Both default to the verifier-wide settings and may be overridden per challenge.
      *
      * Note that the inverse of [Makoto.verificationTimeOffset] is added to the nonce validity period to account for clock drift between clients and server.
@@ -136,7 +136,7 @@ constructor(
         postEndpoint: String,
         timeZone: TimeZone? = null,
         keyConstraints: KeyConstraints? = defaultKeyConstraints,
-        attestableAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = this.attestableAttributes,
+        toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = this.toBeAttestedAttributes,
         dataAuth: DataAuthentication = this.dataAuth,
     ) = AttestationChallenge(
         issuedAt = makoto.clock.now() - makoto.verificationTimeOffset,
@@ -147,7 +147,7 @@ constructor(
         proofOID = attestationProofOID,
         genericDeviceNameOID = genericDeviceNameOID,
         keyConstraints = keyConstraints,
-        attestableAttributes = attestableAttributes,
+        toBeAttestedAttributes = toBeAttestedAttributes,
         dataAuth = dataAuth,
     ).also { challengeValidator.store(it) }
 
@@ -693,7 +693,7 @@ constructor(
                 defaultKeyConstraints = configuration.defaultKeyConstraints,
                 nonceValidity = makoto.longestValidityDuration
                     ?: IosAttestationConfiguration.DEFAULT_VALIDITY_SECONDS.seconds,
-                attestableAttributes = configuration.attestableAttributes,
+                toBeAttestedAttributes = configuration.toBeAttestedAttributes,
                 dataAuth = configuration.dataAuthentication,
                 nonceGenerator = nonceGenerator,
                 challengeValidator = challengeValidator(

--- a/supreme/verifier/src/jvmMain/kotlin/SupremeConfiguration.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/SupremeConfiguration.kt
@@ -39,7 +39,7 @@ import kotlin.time.Duration
  * @property defaultKeyConstraints Configuration for default key constraints, such as supported cryptographic operations.
  * @property dataAuthentication Default authentication mode placed in issued challenges. Signature mode proves private-key
  * possession; hash mode binds the TBS CSR contents through the platform attestation nonce without signing it.
- * @property attestableAttributes Optional ordered client-provided values to request and bind into every issued challenge.
+ * @property toBeAttestedAttributes Optional ordered client-provided values to request and bind into every issued challenge.
  */
 @ExposedCopyVisibility
 @Serializable
@@ -57,7 +57,7 @@ private constructor(
     val defaultKeyConstraints: KeyConstraints? = WardenDefaults.KeyConstraints.p256Signer,
     val dataAuthentication: DataAuthentication = DataAuthentication.Signature,
     @Serializable(with = ConfigurationAttestableAttributesSerializer::class)
-    val attestableAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+    val toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
 ) : AttestationConfiguration {
 
     @Throws(AttestationException.Configuration::class, IllegalArgumentException::class)
@@ -70,7 +70,7 @@ private constructor(
         genericDeviceNameOID: ObjectIdentifier? = WardenDefaults.OIDs.DEVICE_NAME,
         defaultKeyConstraints: KeyConstraints? = WardenDefaults.KeyConstraints.p256Signer,
         dataAuth: DataAuthentication = DataAuthentication.Signature,
-        attestableAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+        toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
     ) : this(
         ios,
         android,
@@ -80,7 +80,7 @@ private constructor(
         genericDeviceNameOID,
         defaultKeyConstraints,
         dataAuth,
-        attestableAttributes
+        toBeAttestedAttributes
     )
 
     /**
@@ -95,7 +95,7 @@ private constructor(
         genericDeviceNameOID: ObjectIdentifier? = WardenDefaults.OIDs.DEVICE_NAME,
         defaultKeyConstraints: KeyConstraints? = WardenDefaults.KeyConstraints.p256Signer,
         dataAuth: DataAuthentication = DataAuthentication.Signature,
-        attestableAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+        toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
     ) : this(
         ios,
         null,
@@ -105,7 +105,7 @@ private constructor(
         genericDeviceNameOID,
         defaultKeyConstraints,
         dataAuth,
-        attestableAttributes,
+        toBeAttestedAttributes,
     )
 
     /**
@@ -120,7 +120,7 @@ private constructor(
         genericDeviceNameOID: ObjectIdentifier? = WardenDefaults.OIDs.DEVICE_NAME,
         defaultKeyConstraints: KeyConstraints? = WardenDefaults.KeyConstraints.p256Signer,
         dataAuth: DataAuthentication = DataAuthentication.Signature,
-        attestableAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+        toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
     ) : this(
         null,
         android,
@@ -130,7 +130,7 @@ private constructor(
         genericDeviceNameOID,
         defaultKeyConstraints,
         dataAuth,
-        attestableAttributes,
+        toBeAttestedAttributes,
     )
 
     init {
@@ -271,12 +271,12 @@ private object ConfigurationAttestableAttributesSerializer :
                     CompositeDecoder.DECODE_DONE -> break
                     0 -> oid = decodeSerializableElement(descriptor, 0, ObjectIdentifierStringSerializer)
                     1 -> attributes = decodeSerializableElement(descriptor, 1, attributesSerializer)
-                    else -> throw SerializationException("Unknown AttestableAttributes element index: $index")
+                    else -> throw SerializationException("Unknown toBeAttestedAttributes element index: $index")
                 }
             }
             AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
-                requireNotNull(oid) { "Missing AttestableAttributes.oid" },
-                requireNotNull(attributes) { "Missing AttestableAttributes.attributes" },
+                requireNotNull(oid) { "Missing toBeAttestedAttributes.oid" },
+                requireNotNull(attributes) { "Missing toBeAttestedAttributes.attributes" },
             )
         }
 }

--- a/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierHashedAttributesTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierHashedAttributesTest.kt
@@ -75,7 +75,7 @@ private suspend fun hashedProofFixture(
     val challenge = verifier.issueChallenge(
         attestationEndpoint,
         keyConstraints = WardenDefaults.KeyConstraints.p256Signer,
-        attestableAttributes = hashedAttributeRequest,
+        toBeAttestedAttributes = hashedAttributeRequest,
         dataAuth = authentication,
     )
     val tbsCsr = hashInput.toTbsCsr(

--- a/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierOidUniquenessTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierOidUniquenessTest.kt
@@ -27,7 +27,7 @@ val AttestationVerifierOidUniquenessTest by matrixSuite {
         ) else null
         val challenge = verifier.issueChallenge(
             attestationEndpoint,
-            attestableAttributes = requested,
+            toBeAttestedAttributes = requested,
         )
         val proof = Pkcs10CertificationRequestAttribute(
             challenge.proofOID,

--- a/supreme/verifier/src/jvmTest/kotlin/examples/ConfigGen.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/ConfigGen.kt
@@ -195,7 +195,7 @@ val ConfigurationExampleGenerator by matrixSuite(matrixConfig { execution = Exec
         androidAttestationConfiguration,
         iosAttestationConfiguration,
         dataAuth = DataAuthentication.Hash(Digest.SHA256),
-        attestableAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
+        toBeAttestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
             oid = ObjectIdentifier("2.25.304198582559398858370235454530489176240"),
             attributes = listOf(
                 AttestationChallenge.AttributeAttestationDescriptor("accountId", PrimitiveType.STRING),

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier.kt
@@ -48,7 +48,7 @@ val verifier = AttestationVerifier(
     nonceValidity = 5.minutes, //DEFAULT
     nonceGenerator = suspend { CryptoRand.nextBytes(ByteArray(/*(5)!*/128)) },
  /*(6)!*/challengeValidator = redisBacked,
- /*(7)!*/attestableAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
+ /*(7)!*/toBeAttestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
         customerAttributesOID,
         listOf(
             AttestationChallenge.AttributeAttestationDescriptor("accountId", PrimitiveType.STRING),

--- a/supreme/verifier/src/jvmTest/kotlin/main.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/main.kt
@@ -188,7 +188,7 @@ val TestEnv by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEn
                                 "$ENDPOINT_ATTEST/$scenarioName",
                                 timeZone = TimeZone.currentSystemDefault(),
                                 keyConstraints = WardenDefaults.KeyConstraints.p256Signer,
-                                attestableAttributes = scenario.expectedAttributes?.let { requestedAttributes },
+                                toBeAttestedAttributes = scenario.expectedAttributes?.let { requestedAttributes },
                                 dataAuth = scenario.authentication,
                             )
                         )


### PR DESCRIPTION
## PR 3/3 (build system + dependency foo)

* **Selectable attestation-proof authentication and attested client attributes**
    * Add `DataAuthentication.Signature` (default) and `DataAuthentication.Hash` challenge modes.
    * Signature mode preserves the existing signed-PKCS#10 behaviour and proof-of-possession check.
    * Hash mode returns an unsigned TBS CSR and binds its version, subject, extensions, and non-proof attributes through
      a canonical DER hash used as the platform attestation nonce. It deliberately does not prove possession.
    * Always verify that the public key in the received TBS CSR matches the key proven by the platform attestation.
    * Add `AttestationProof` as the verifier/client transport abstraction and structurally decode its DER as either
      a complete CSR or TBS CSR. Hash algorithms remain challenge-owned and are never supplied with client transport.
      Deprecate CSR-only overloads; they reject hash authentication and requested attributes instead of silently changing
      behaviour.
    * Add ordered required/optional client-provided attributes using `AttestableAttributes`, `ToBeAttestedAttribute`,
      `PrimitiveType`, and ASN.1 codecs. Values are authenticated by either supported mode.
    * Move authentication selection from optional `KeyConstraints` into `AttestationChallenge`.
    * Add canonical `AttestationHashInput` conversion to and from TBS CSR data, excluding only the public key and exactly
      one attestation-proof attribute.
    * Reject authentication-mode mismatches, duplicate CSR attribute/extension OIDs, malformed extension requests,
      non-canonical attribute order, key mismatches, and missing or invalid requested attributes.
    * Route all new verifier validation failures through `onPreAttestationError` as typed
      `PreAttestationError.ClientDataValidation` values.
    * Add `dataAuthentication` and human-readable `attestableAttributes` support to `SupremeConfiguration` JSON/YAML.
    * Expand client, verifier, property, and Android-emulator end-to-end coverage for both authentication modes and
      required/optional attribute combinations.
* Add Supreme dependency to `supreme-common`
* Dependency Updates
    * KeyAttestation [47f970d044ae4da7b00da068e7e1a4e952b0fd2f](https://github.com/android/keyattestation/commit/47f970d044ae4da7b00da068e7e1a4e952b0fd2f)
    * AGP 9.1.1
    * Gradle 9.6.1
    * Kotlin 2.4.10
    * TestBalloon 1.0.1
    * TestBalloon Addon 0.16.0