### PR TITLE
feature/hashed PR 2/3 (Docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ Since Warden Supreme is an evolution of WARDEN and continues to maintain and pub
 dedicated artefacts,
 this changelog also includes the original WARDEN changelog.
 
+## NEXT
+* **Selectable attestation-proof authentication and attested client attributes**
+    * Add `DataAuthentication.Signature` (default) and `DataAuthentication.Hash` challenge modes.
+    * Signature mode preserves the existing signed-PKCS#10 behaviour and proof-of-possession check.
+    * Hash mode returns an unsigned TBS CSR and binds its version, subject, extensions, and non-proof attributes through
+      a canonical DER hash used as the platform attestation nonce. It deliberately does not prove possession.
+    * Always verify that the public key in the received TBS CSR matches the key proven by the platform attestation.
+    * Add `AttestationProof` as the verifier/client transport abstraction and structurally decode its DER as either
+      a complete CSR or TBS CSR. Hash algorithms remain challenge-owned and are never supplied with client transport.
+      Deprecate CSR-only overloads; they reject hash authentication and requested attributes instead of silently changing
+      behaviour.
+    * Add ordered required/optional client-provided attributes using `AttestableAttributes`, `ToBeAttestedAttribute`,
+      `PrimitiveType`, and ASN.1 codecs. Values are authenticated by either supported mode.
+    * Move authentication selection from optional `KeyConstraints` into `AttestationChallenge`.
+    * Add canonical `AttestationHashInput` conversion to and from TBS CSR data, excluding only the public key and exactly
+      one attestation-proof attribute.
+    * Reject authentication-mode mismatches, duplicate CSR attribute/extension OIDs, malformed extension requests,
+      non-canonical attribute order, key mismatches, and missing or invalid requested attributes.
+    * Route all new verifier validation failures through `onPreAttestationError` as typed
+      `PreAttestationError.ClientDataValidation` values.
+    * Add `dataAuthentication` and human-readable `attestableAttributes` support to `SupremeConfiguration` JSON/YAML.
+    * Expand client, verifier, property, and Android-emulator end-to-end coverage for both authentication modes and
+      required/optional attribute combinations.
+* Add Supreme dependency to `supreme-common`
+* Dependency Updates
+    * KeyAttestation [47f970d044ae4da7b00da068e7e1a4e952b0fd2f](https://github.com/android/keyattestation/commit/47f970d044ae4da7b00da068e7e1a4e952b0fd2f)
+    * AGP 9.1.1
+    * Gradle 9.6.1
+    * Kotlin 2.4.10
+    * TestBalloon 1.0.1
+    * TestBalloon Addon 0.16.0
+
 # 1.0.2
 * Ktor 3.5.1
 * kotlinx.datetime 0.8.0

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -12,7 +12,11 @@ This glossary centralises terms used across the documentation. Each entry is con
     - **App Attestation** — A statement about the app (e.g., unmodified app, signed by the developer, running on an unmodified OS).
 - **Attestation Statement** — The platform-generated attestation payload (Android: X.509 chain with KeyDescription; iOS: App Attest payload).
 - **Attestation Object (iOS)** — Apple’s App Attest CBOR structure (`authenticatorData`, `attStmt`, `x5c`) returned by `attestKey`.
-- **Attestation Proof** — The transport container sent to the server, typically a CSR carrying the attestation statement payload.
+- **Attestation Proof** — The authenticated transport sent to the server: either a signed CSR or a hash-bound unsigned TBS CSR carrying the attestation statement payload.
+- **Proof of Possession** — Evidence that the client can use the private key corresponding to a public key. Warden Supreme
+  obtains this from the CSR signature in `DataAuthentication.Signature` mode. Hash mode deliberately omits it.
+- **Data Authentication** — *(In the context of Warden Supreme!)* The challenge-selected mechanism binding TBS CSR contents to the ceremony: a CSR signature,
+  or a digest incorporated into the platform attestation nonce.
 - **Challenge / Nonce** — A server‑generated, unpredictable byte string used exactly once to guarantee freshness and prevent replay. Android embeds it in the attestation extension; iOS mixes it into the attestation nonce via `clientDataHash` (see [Android Key Attestation]({{ links.android_key_attestation }}), [Attestation Object Validation Guide]({{ links.ios_attestation_validation }})).
 - **Binding** — Cryptographically tying data (e.g., public key bytes + challenge) into an attested statement so the verifier can trust their association.
 
@@ -27,7 +31,15 @@ This glossary centralises terms used across the documentation. Each entry is con
 - **X.509 Certificate Chain** — Sequence of certificates from leaf (key’s cert) → intermediate(s) → root (trust anchor). Android attestation uses an X.509 leaf carrying an attestation extension (see [Android Key Attestation]({{ links.android_key_attestation }})).
 - **Leaf / Intermediate / Root** — The key’s certificate is the leaf; intermediates link to a root certificate that the verifier trusts.
 - **Trust Anchor** — Known‑good root certificate or public key the verifier explicitly trusts (e.g., Google’s Hardware Attestation Root, Apple’s App Attest Root) (see [Android Key Attestation]({{ links.android_key_attestation }}), [Attestation Object Validation Guide]({{ links.ios_attestation_validation }})).
-- **PKCS#10 / CSR (Certificate Signing Request)** — Signed request carrying a public key and optional attributes/extensions; Warden Supreme embeds attestation payloads in CSR attributes and binds the nonce via the CSR subject.
+- **PKCS#10 / CSR (Certificate Signing Request)** — A signed request containing a CertificationRequestInfo (TBS CSR), a
+  signature algorithm, and a signature. Warden Supreme signature mode sends the complete CSR; hash mode sends only the
+  unsigned TBS CSR.
+- **TBS CSR / CertificationRequestInfo** — The part of a PKCS#10 request containing version, subject, public key, and
+  attributes (including requested extensions). It is signed in signature mode and hash-bound in hash mode.
+- **AttestationHashInput** — Canonical DER projection of a TBS CSR excluding its public key and single attestation-proof
+  attribute. Its digest becomes the platform attestation nonce in hash mode.
+- **Attested Client Attribute** — A typed value supplied by verified application code and bound into the TBS CSR. It is
+  software-attested rather than independently asserted by the device hardware or OS.
 - **OID (Object Identifier)** — Hierarchical identifier used in X.509 and CSR attributes/extensions; used to identify custom attestation payloads and optional device-name attributes.
 - **PKI / PKIX** — Public Key Infrastructure and its X.509 profile; governs certificate path validation, constraints, and revocation semantics.
 - **ASN.1 / DER** — Encoding rules used in X.509 and Android’s attestation extension.

--- a/docs/docs/integration/config.md
+++ b/docs/docs/integration/config.md
@@ -136,8 +136,8 @@ It includes both the platform-specific configurations and the properties related
 
 Two integrated-flow properties control proof authentication and client-provided attested values:
 
-* `dataAuthentication` defaults to signature mode. Use `{ "type": "Signature" }` for a signed CSR with proof of
-  possession, or `{ "type": "hash", "algorithm": "SHA256" }` for an unsigned TBS CSR whose canonical hash input is
+* `dataAuthentication` defaults to signature mode. Use `{ "type": "SIGNATURE" }` for a signed CSR with proof of
+  possession, or `{ "type": "HASH", "algorithm": "SHA256" }` for an unsigned TBS CSR whose canonical hash input is
   bound through the platform attestation nonce.
 * `attestableAttributes` is optional. It defines the dedicated CSR attribute OID and an ordered list of values. `type`
   uses readable `PrimitiveType` names (`STRING`, `INT`, `BOOLEAN`, `BYTEARRAY`, etc.); `required` defaults to `true`.

--- a/docs/docs/integration/config.md
+++ b/docs/docs/integration/config.md
@@ -134,6 +134,23 @@ In addition, approaches based on reflection that do not invoke the configuration
 To externalise configuration for fully integrated attestation flows conveniently, use the umbrella `SupremeConfiguration`.
 It includes both the platform-specific configurations and the properties related to fully integrated attestation itself.
 
+Two integrated-flow properties control proof authentication and client-provided attested values:
+
+* `dataAuthentication` defaults to signature mode. Use `{ "type": "Signature" }` for a signed CSR with proof of
+  possession, or `{ "type": "hash", "algorithm": "SHA256" }` for an unsigned TBS CSR whose canonical hash input is
+  bound through the platform attestation nonce.
+* `attestableAttributes` is optional. It defines the dedicated CSR attribute OID and an ordered list of values. `type`
+  uses readable `PrimitiveType` names (`STRING`, `INT`, `BOOLEAN`, `BYTEARRAY`, etc.); `required` defaults to `true`.
+
+The generated YAML and JSON examples below demonstrate hash authentication together with one required and one optional
+attestable attribute. Their example OID is the freely assignable UUID-based OID for
+`e4da8413-46ae-4f0f-88f5-c7325b5850b0`. Generate a fresh UUID-derived `2.25` OID for your own attribute instead of
+borrowing an enterprise subtree you do not control.
+
+These are verifier defaults copied into each issued `AttestationChallenge`; `issueChallenge` can override them per
+ceremony. `AttestationProof.decodeFromDer` distinguishes a complete CSR from an unsigned TBS CSR structurally. The
+matched challenge—not the HTTP layer or client transport—selects the expected mode and hash algorithm.
+
 Both `AndroidAttestationConfiguration` and `IosAttestationConfiguration` are useful on their own if you don't opt for
 fully integrated attestation, which is why they also have canonical serialised representations (JSON and YAML) and
 expose the same (de)serialisation functions as `SupremeConfiguration`.
@@ -141,7 +158,8 @@ expose the same (de)serialisation functions as `SupremeConfiguration`.
 ??? example "YAML with Defaults for a Sample Android and iOS App"
     The below example shows every configuration property in YAML form.
     It uses a single Android app and a single iOS app. Android revocation checks use the default Google revocation list,
-    as well as a custom file-based revocation list. All other properties show their default values.  
+    as well as a custom file-based revocation list. It also configures hash authentication and required and optional
+    attestable attributes. All other properties show their default values.
     You can download the below example [here](../examples/supreme.yaml).
     
     ```yaml
@@ -151,7 +169,8 @@ expose the same (de)serialisation functions as `SupremeConfiguration`.
 ??? example "JSON with Defaults for a Sample Android and iOS App"
     The below example shows every configuration property in JSON form.
     It uses a single Android app and a single iOS app. Android revocation checks use the default Google revocation list,
-    as well as a custom file-based revocation list. All other properties show their default values.  
+    as well as a custom file-based revocation list. It also configures hash authentication and required and optional
+    attestable attributes. All other properties show their default values.
     You can download the below example [here](../examples/supreme.json).
     
     ```json

--- a/docs/docs/integration/datamodel.md
+++ b/docs/docs/integration/datamodel.md
@@ -24,22 +24,28 @@ wire up third-party clients. Treat them as experimental for now, as the integrat
 The challenge binds a future attestation proof to a fresh, server-originating value and tells the client where and how
 to respond.
 
-**Fields**
+**Fields:**
+
 - `issuedAt`: when the challenge was issued.
 - `validity`: how long the challenge is valid.
 - `timeZone`: optional server time zone (informational).
 - `nonce`: server-chosen nonce (≤128 bytes). This is sensitive replay-protection material. Treat it as a short-lived bearer value: do not log it, do not expose it across sessions or callers, and serve challenges only over protected transport.
 - `attestationEndpoint`: where the client submits the attestation proof.
-- `proofOID`: CSR attribute identifier used to carry the attestation statement payload.
-- `genericDeviceNameOID`: whether to include a generic make/model (not user-assignable name) in the CSR.
+- `proofOID`: TBS CSR attribute identifier used to carry the attestation statement payload.
+- `genericDeviceNameOID`: whether to include a generic make/model (not user-assignable name) in the TBS CSR.
 - `version`: data format version.
 - `keyConstraints`: desired key parameters and protection policy for the client.
+- `dataAuth`: required proof authentication: signed PKCS#10 (`Signature`, the default) or hash-bound unsigned TBS CSR
+  (`hash` plus a digest algorithm).
+- `toBeAttestedAttributes`: optional OID plus an ordered list of named, typed client-provided values. Each value can be
+  required or optional.
 - `additionalPayload`: optional, service-defined key/value payload to piggyback along with the challenge (see below).
 - `transientData`: optional runtime-only attachment; not serialized and not part of the wire format.
 
 #### `additionalPayload`
-Some deployments carry extra service context with the challenge: a session id, tenant id, UI flow hints, or other
-metadata the client should echo back when submitting the CSR.
+Some deployments carry extra server-side policy context with the challenge: a session id, tenant id, UI flow hints, or
+other metadata available again after the challenge is matched. This is not a client-attested value. Use
+`toBeAttestedAttributes` when the client must supply a value that is cryptographically bound to the ceremony.
 
 `additionalPayload` is a nested map structure:
 - Keys are `String`.
@@ -57,13 +63,37 @@ You may set it when constructing an `AttestationChallenge` on the server, to kee
 
 ### Proof Transport (Client → Server)
 The platform-specific attestation payload (Android Key/ID Attestation, iOS App Attest) is embedded into a PKCS#10
-Certificate Signing Request (CSR) attribute identified by the provided `proofOID`, as a JSON-encoded UTF-8 string inside
-the extension.
+CertificationRequestInfo (TBS CSR) attribute identified by `proofOID`, as a JSON-encoded UTF-8 string. The TBS CSR subject
+encodes the original server nonce in a `serialNumber` RDN. Extensions, the optional generic device name, and requested
+client-provided attributes are carried by the same TBS CSR.
 
-The CSR subject encodes the challenge nonce in a `serialNumber` RDN. The result is a single signed container that carries
-both the device/app attestation and its link to the server’s challenge. In this documentation, "attestation statement"
-means the platform payload, "attestation proof" means the transport container (CSR), and "attestation object" refers
-specifically to iOS App Attest.
+`AttestationProof` makes the two possible transports explicit:
+
+- `Signed` carries a complete PKCS#10 CSR. The client signs the TBS CSR with the attested key, authenticating every field
+  and proving possession of the private key.
+- `Hashed` carries an unsigned TBS CSR. Before generating the attested key, the client DER-encodes an
+  `AttestationHashInput`: the future TBS CSR version, subject, extensions, and attributes, excluding only the not-yet-known
+  public key and attestation-proof attribute. It hashes that structure and uses the digest as the platform attestation
+  nonce. The verifier reconstructs and hashes the same structure and independently checks that the TBS CSR public key is
+  the attested key. This authenticates the included data but deliberately provides no proof of possession.
+
+The raw HTTP body is DER in both cases. `AttestationProof.decodeFromDer` distinguishes a complete CSR from a TBS CSR
+by their different ASN.1 structures; it does not need the challenge or a caller-supplied hash algorithm. The verifier then
+loads the matching challenge, obtains the expected authentication mode and digest algorithm from it, and rejects a
+signed/unsigned shape mismatch.
+
+In this documentation, "attestation statement" means the platform payload, "attestation proof" means either authenticated
+transport, and "attestation object" refers specifically to iOS App Attest.
+
+#### Requested attested attributes
+
+`toBeAttestedAttributes` defines one dedicated CSR attribute OID and an ordered schema. Each value is encoded at its list
+position using `PrimitiveType`; optional missing values are represented as ASN.1 `NULL`. The client callback receives the
+schema and must return exactly one value per entry. Required values cannot be `null`.
+
+These values originate in application code and are therefore "software-attested": they are trustworthy only to the extent
+that the verified app and the selected authentication mode are trusted. They are bound by the CSR signature in signature
+mode and by `AttestationHashInput` in hash mode.
 
 ### Server Response (Server → Client)
 The response is an `either` type:
@@ -83,12 +113,16 @@ attestation exceptions are mapped into one of these four buckets (see [Error Han
     - Untrusted or mismatched root/intermediate (e.g., wrong environment or CA).
     - App identity mismatch (Team ID / Bundle ID, package signature digest, etc.).
     - Device state non-compliance (e.g., verified boot state, patch level, production vs. sandbox).
+    - The public key claimed by the CSR does not match the key proven by the attestation statement.
+    - The submitted transport does not provide the authentication mode required by the challenge.
 - `TIME`: timing and validity issues, such as:
     - Challenge expired or not yet valid.
     - Excessive clock skew between client and server.
     - Certificate or attestation statement outside its validity window.
 - `CONTENT`: malformed, missing, or semantically invalid input, such as:
     - CSR missing the expected attribute (`proofOID`) or an unparsable payload.
+    - Duplicate attribute or extension OIDs, malformed extension requests, or non-canonical DER attribute order.
+    - Missing, malformed, unexpected, or type-invalid requested attributes.
     - Nonce binding absent, incorrect, or not issued by the server.
     - Attestation statement fails policy checks (package name, signer digest, boot state, rollback resistance, OS/app version, security level).
     - Platform configuration mismatch (e.g., statement received for a non-configured platform).
@@ -99,10 +133,15 @@ attestation exceptions are mapped into one of these four buckets (see [Error Han
     - Unexpected exceptions not attributable to client input.
 
 ## How Verification Ties Together
-The server extracts the challenge nonce from the CSR subject and the attestation statement from the CSR attribute
+The server extracts the original challenge nonce from the TBS CSR subject and the attestation statement from the attribute
 identified by `proofOID`, then validates:
 
-- **Challenge binding**: the nonce must match the exact server-issued nonce and it must not be expired.
+- **Challenge binding**: the nonce must identify the exact server-issued, unexpired challenge.
+- **Authentication mode**: signed and hashed transports are not interchangeable.
+- **Data binding**: verify the CSR signature and proof of possession in signature mode, or recompute the canonical hash
+  input in hash mode.
+- **Key binding**: the TBS CSR public key must equal the key proven by platform attestation in both modes.
+- **Requested attributes**: the dedicated attribute must match the challenge's ordered types and required/optional rules.
 - **Platform trust and policy**: certificate chain, environment (prod/sandbox), app identity, device state, counters/continuity
   (see [iOS deep dive](../technical/ios.md)), boot/patch state (see [Android deep dive](../technical/android.md)).
 - **Time**: issuance time and validity windows for replay protection. See also [Clock Drifts and Temporal Validity](../technical/quirks.md#clock-drifts-and-temporal-validity).

--- a/docs/docs/integration/errorhandling.md
+++ b/docs/docs/integration/errorhandling.md
@@ -104,7 +104,8 @@ offline analysis.
 
 ### Pre-Attestation Errors
 When using fully integrated attestation, preprocessing steps are automatically performed to extract, check, and invalidate
-the received challenge, parse the received CSR, extract the attestation proof (CSR), and so forth.
+the received challenge, parse the signed CSR or unsigned TBS CSR, extract the attestation statement, validate the selected
+authentication mode and canonical CSR structure, match the attested public key, and decode requested attributes.
 Naturally, this does not always work as arbitrary data can be sent to the verifier, which means pre-attestation
 errors can occur.  
 The following snippet shows how to react to such errors.
@@ -112,23 +113,32 @@ Note that the `onPreAttestationError` callback is side-effect-free except that i
 to customise the error message/error code conveyed to the client.
 
 ```kotlin
---8<-- "Readme-Backend-preerrorhandling.kt:15:40"
+--8<-- "Readme-Backend-preerrorhandling.kt:16:38"
 ```
 
-1. Refer to [Debugging](debugging.md)
-2. Certificate is not yet valid or expired. Clock drift is the main source for this error.
-3. An untrusted root certificate was encountered. E.g., an Android Emulator was used in production.
-4. Thrown when an attestation statement is received for a platform that is not configured.
+1. The attestation statement could not be extracted from the received transport. New code receives
+   `AugmentedAttestationStatementExtraction`, which contains `AttestationProof`; the CSR-only class is retained for
+   the deprecated verifier overload.
+2. The nonce/challenge could not be extracted from the received TBS CSR.
+3. Challenge verification or an operational pre-attestation step failed.
+4. `ClientDataValidation` exposes a precise `reason`, the received transport, the validated challenge, and the underlying
+   throwable. Reasons cover authentication-mode mismatch, duplicate attribute/extension OIDs, malformed extension
+   requests, non-canonical attribute order, hash binding, public-key mismatch, and requested-attribute extraction/matching.
+
+The callback's non-null return value becomes the client-facing explanation. Exceptions thrown by this observation callback
+are ignored and the verifier uses its safe fallback explanation.
 
 
 ## Client-Side (Generic, High-Level Error Categories)
 Using fully integrated attestation only ever returns either an `AttestationResponse.Success`
 or an `AttestationResponse.Failure`. The latter indicates one of four error reasons:
 
-1. `TRUST` encompassing untrusted roots, revoked certificates, or invalid certificate chains
+1. `TRUST` encompassing untrusted roots, revoked certificates, invalid certificate chains, invalid CSR signatures, a
+   public key that does not match the attested key, or a transport that does not provide the authentication mode required
+   by the challenge
 2. `TIME` encompassing temporal validity errors with respect to certificates and attestation statements 
-3. `CONTENT` encompassing all cases where the attestation statement itself failed to parse or verify against the policy
-   (i.e. Android devices having an unlocked bootloader, even though the policy mandates a locked bootloader and a factory image)
+3. `CONTENT` encompassing cases where the attestation statement fails to parse or verify against policy, and invalid proof
+   transport content such as ambiguous/malformed CSR attributes or missing/invalid requested attributes
 4. `INTERNAL` encompassing errors on a more fundamental level, such as a structurally valid CSR, but using unsupported signature algorithms, for example,
    or outright implementation issues in Warden Supreme.
 

--- a/docs/docs/integration/migration.md
+++ b/docs/docs/integration/migration.md
@@ -29,6 +29,28 @@ Warden Supreme enforces unified flows and a unified data model. Migration mostly
     [Usage without Integrated Clients](raw.md) (Makoto/Roboto directly),
     and [Externalising Configuration](config.md) (canonical config loading).
 
+## Migrating to Warden Supreme 1.1+
+
+!!! note 
+    This section is targets integrators coming from Warden Supreme 1.0.x.
+
+The integrated transport is no longer unconditionally a signed CSR. New code uses `AttestationProof` end to end:
+
+- `AttestationProof.Signed` wraps the existing complete CSR and preserves proof-of-possession behaviour.
+- `AttestationProof.Hashed` wraps an unsigned TBS CSR whose canonical non-key, non-proof contents are authenticated
+  through the platform attestation nonce.
+- `AttestationChallenge.dataAuth` selects the required mode independently of optional `keyConstraints`.
+- `AttestationChallenge.toBeAttestedAttributes` can request ordered required/optional client-provided values.
+
+Update `AttestationClient.attest`, `AttestationVerifier.verifyAttestation`, `onChallengeValidated`,
+`additionalVerifications`, and the certificate issuer to accept `AttestationProof`. The old CSR-only overloads are
+deprecated compatibility paths: they continue to support signature authentication without requested attributes and reject
+new semantics explicitly.
+
+Use `AttestationProof.decodeFromDer` at HTTP boundaries. It infers complete CSR versus TBS CSR from the ASN.1 shape,
+without accepting a hash algorithm from the caller. The verifier obtains the expected mode and digest algorithm from the
+matched challenge and rejects a submitted shape that does not match it.
+
 ## Changes (Makoto + Roboto APIs)
 This section focuses on upgrades that keep using `Makoto` / `Roboto` directly, without adopting the integrated model.
 

--- a/docs/docs/integration/supreme.md
+++ b/docs/docs/integration/supreme.md
@@ -45,16 +45,46 @@ The back-end, however, can also use [Spring](https://spring.io/) or any other HT
 An attestation flow works as follows, in accordance with Figure&nbsp;1:
 
 1. The client fetches a challenge from the back-end.
-2. The client feeds the challenge into hardware-backed key generation to create an attestation statement.
-3. The client sends the attestation proof (CSR) back to the back-end.
-    * **Wire-format-wise, this is a CSR with a custom attribute carrying the attestation statement payload**
-    * CSRs were chosen because their canonical encoding is precisely specified and because they inherently come with a proof of possession of the private key
-    * CSRs allow defining arbitrary extensions and attributes, which is a perfect fit for Warden Supreme's usage scenario
-    * Finally, the PKIX context is the natural habitat of a CSR
+2. The client prepares the TBS CSR data and feeds either the server nonce or a hash of that data into hardware-backed key
+   generation to create an attestation statement.
+3. The client sends the challenge-selected attestation proof back to the back-end.
+    * `DataAuthentication.Signature` (the default) sends a complete signed CSR and therefore proves possession of the
+      attested private key.
+    * `DataAuthentication.Hash` sends an unsigned TBS CSR. Its version, subject, extensions, and all non-proof attributes
+      are bound through a canonical DER hash used as the platform attestation nonce. This mode deliberately provides no
+      proof of possession.
+    * Both modes carry the attestation statement in a custom TBS CSR attribute and can bind required or optional
+      client-provided attributes.
+    * The public key cannot be part of the pre-generation hash, so the verifier separately requires it to equal the key
+      proven by the platform attestation.
 4. The back-end verifies the attestation statement against a predefined policy.
     * If the attestation is considered valid, the back-end issues a certificate for the attested key, thus vouching for the integrity of the client.
     * If the attestation does not verify, the back-end records the reason for this failure.
 5. The back-end responds either with the full certificate chain (success) or a detailed error reason (failure).
+
+### Choosing an Authentication Mode
+
+Use signature mode when the ceremony must prove that the client can operate the attested private key at that moment. This
+is the default. If key use requires biometric or device authentication, creating the
+CSR signature may display the configured authentication prompt.
+
+Use hash mode when binding the request data and attested key is sufficient and an immediate private-key operation is
+undesirable. Hash mode authenticates the TBS CSR contents but is **not** a proof of possession. A valid platform
+attestation still proves how and where the key was generated, and the verifier still matches that attested key to the TBS
+CSR public key.
+
+The modes are not interchangeable: the verifier rejects a signed CSR for a hash challenge and an unsigned TBS CSR for a
+signature challenge.
+
+### Requesting Client-Provided Attributes
+
+The verifier can place an `AttestableAttributes` schema in a challenge. It contains a dedicated attribute OID and an
+ordered list of `ToBeAttestedAttribute(name, type, required)` entries. The client callback receives that list and returns
+one `Primitive` per entry. Required values must be present; optional values can be `null`.
+
+These values are produced by the app, not independently certified by Android or Apple. Successful verification means the
+expected app supplied them and the selected authentication mode bound them into this ceremony.
+Both signature and hash mode bind the same attribute sequence.
 
 <figure>
 <picture>
@@ -284,10 +314,10 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
 
 ??? example "Comprehensive list of Verifier options"
     ```kotlin
-    --8<-- "Readme-Verifier.kt:20"
+    --8<-- "Readme-Verifier.kt:30"
     ```
     
-    1. We want Warden Supreme to convey the attestation statement payload inside the CSR using a custom OID.
+    1. We want Warden Supreme to convey the attestation statement payload inside the TBS CSR using a custom OID.
     2. We don't care about device names in this example.
     3. We explicitly specify the key we want to have created on the client.  
        The values shown here correspond to the defaults, as this is supported by Android and iOS.
@@ -297,11 +327,15 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
         * Enrolling new biometric factors will invalidate the key
     5. We want extra long nonces (default: 64 bytes; max: 128 bytes).
     6. Checking and invalidating challenges is handled by a Redis-backed cache (not shown here; roll your own). This is the recommended approach when multiple verifier instances issue challenges.
+    7. Request two application-provided values under one dedicated attribute OID. `accountId` is required; `riskScore`
+       may be omitted as `null`. Order and type are part of the schema.
+    8. Authenticate the TBS CSR data by hashing it with SHA-256 and feeding the digest into platform attestation. Set
+       `DataAuthentication.Signature` (the default) when proof of possession is required.
     
 
 Instead of passing parameters programmatically, it is also possible to externalise configuration (see [Externalising Configuration](config.md)).
 As such, an `AttestationVerifier` can also be created by passing a `SupremeConfiguration` which contains iOS and Android
-attestation policies, as well as everything needed on top (object identifiers, etc.):
+attestation policies, as well as object identifiers, key constraints, authentication mode, and requested attributes:
 
 ```kotlin
 --8<-- "Readme-Verifier-config-supreme.kt:15"
@@ -315,7 +349,8 @@ attestation policies, as well as everything needed on top (object identifiers, e
 `Makoto` verifies the generic platform and app attestation policy: challenge freshness, attestation statement validity,
 trust anchors, app identifiers, signer digests, boot state, OS and app version constraints, and similar platform-specific
 properties. Some back-ends also need service-specific checks on top of that policy, for example tenant binding, account
-state, risk engine decisions, device inventory rules, or values carried in `AttestationChallenge.additionalPayload`.
+state, risk engine decisions, device inventory rules, or client-provided attested attributes. `additionalPayload` is
+server-controlled context sent to the client; it is not client evidence to validate on receipt.
 
 Use `additionalVerifications` for such checks:
 
@@ -323,10 +358,13 @@ Use `additionalVerifications` for such checks:
 --8<-- "Readme-Backend-additional-verifications.kt:17:33"
 ```
 
-1. This is the verified CSR from the client.
-2. `additionalVerifications` runs after challenge validation, attestation verification, and CSR signature verification.
-   The validated `AttestationChallenge` is the receiver; the CSR and verified attestation result are parameters.
-3. Challenge payload can carry service context that is not part of generic platform attestation policy.
+1. This is the `AttestationProof` received from the client: a signed CSR or hash-authenticated TBS CSR.
+2. `additionalVerifications` runs after challenge validation, attestation verification, public-key matching, requested
+   attribute validation, and the challenge-selected authentication check (including CSR signature verification in
+   signature mode). The validated `AttestationChallenge` is the receiver; the proof transport and verified attestation
+   result are parameters.
+3. `receivedProof.attestedAttributes` parses the client-provided values using the schema from the validated challenge and
+   exposes them by configured name. Optional absent values map to `null`.
 4. Return an `AttestationResponse.Failure` to stop the flow with your own failure kind and explanation.
 5. Return `null` to continue to certificate issuance.
 6. Certificate issuance only runs if generic attestation and all additional checks succeed.
@@ -346,19 +384,22 @@ the certificate issuer.
 This example assumes Ktor. Since this is an example environment, TLS is omitted for brevity.
 
 ```kotlin
---8<-- "Readme-Backend.kt:50"
+--8<-- "Readme-Backend.kt:60"
 ```
 
 1. We're using JSON to transmit the challenge and the final response.
 2. Endpoint to serve challenges to clients
 3. It does nothing but issue challenges. In production, catch `InMemoryChallengeCache.ChallengeCacheFullException` here and return `429 Too Many Requests`; apply caller-aware rate limiting outside the verifier.
 4. The full URL to post the attestation proof to
-5. Endpoint expecting CSRs containing attestation statement payloads
-6. Read the raw CSR from the HTTP body
+5. Endpoint expecting DER-encoded attestation proofs.
+6. `AttestationProof.decodeFromDer` distinguishes the complete-CSR and TBS-CSR ASN.1 structures.
+   The verifier obtains the expected mode and algorithm from the matched challenge and rejects a shape
+   mismatch.
 7. Here, inside the `verifyAttestation` lambda, we already have a verified attestation according to the configured `makoto` instance.
 8. Signing a `TbsCertificate` automatically creates an X.509 certificate
 9. The contents of your leaf certificate are up to you! What follows is just an example.
-10. `it` is the CSR. Remember: The key from the CSR is already attested here!
+10. The certificate issuer receives `AttestationProof`. Its TBS CSR public key has already been matched to the
+    attested key, regardless of authentication mode.
 11. Build the full certificate chain
 12. Finally, respond with the result:
     * On success, the certificate chain produced above will be returned.
@@ -391,17 +432,24 @@ Doing so allows for obtaining a certificate chain for an attested key in literal
 specifies key constraints:
 
 ```kotlin
---8<-- "Readme-client-min.kt:19:35"
+--8<-- "Readme-client-min.kt:19:40"
 ```
 
 1. Create an `AttestationClient` from a [Ktor](https://ktor.io/) client.
 2. Perform the fully integrated attestation flow **iff key constraints are defined in the challenge** consisting of the following steps:
     1. Fetches the challenge from `ENDPOINT_CHALLENGE` 
     2. Automatically creates a key for `ALIAS` and an accompanying attestation statement payload. **Beware:** if a key for this alias exists, this will fail!
-    3. Creates and signs a CSR, feeding the challenge and attestation statement payload into it.
-    4. Sends it to the endpoint encoded in the received challenge.
-3. If everything worked out, store the received certificate chain using whatever storage approach you choose
-4. The kind of error tells you what went wrong. An `AttestationResponse.Failure` **may** also contain a string explaining further details.
+    3. Builds the challenge-selected proof: either a signed CSR with proof of possession or a hash-authenticated unsigned
+       TBS CSR.
+    4. Calls the attribute provider once if the verifier requested client-provided values. The returned values must match
+       the requested order and types; required values cannot be `null`.
+    5. Sends it to the endpoint encoded in the received challenge.
+3. Supply the required `accountId` requested by the verifier. Its value must match the declared `PrimitiveType.STRING`;
+   returning `null` for a required attribute is rejected before the proof is sent.
+4. The verifier declared `riskScore` optional, so the provider may return `null`. The list must still contain an entry for it,
+   preserving the exact order of the challenge's requested-attribute schema.
+5. If everything worked out, store the received certificate chain using whatever storage approach you choose
+6. The kind of error tells you what went wrong. An `AttestationResponse.Failure` **may** also contain a string explaining further details.
 
 This really is it! If you've made it this far, you have successfully issued certificates to mobile clients that fulfil your policy.
 The `AttestationClient` doesn't even come with any configuration options.
@@ -410,31 +458,38 @@ The `AttestationClient` doesn't even come with any configuration options.
     If you need more control, you can also manually perform individual steps, as shown below
     
     ```kotlin
-    --8<-- "Readme-client-step-by-step.kt:20:45"
+    --8<-- "Readme-client-step-by-step.kt:15:45"
     ```
     
     1. Create an `AttestationClient` from a [Ktor](https://ktor.io/) client.
     2. Fetch the challenge
-    3. Create a local attestation proof (a signed CSR) to be sent to the verifier
+    3. Create the signed or hash-authenticated proof selected by the challenge and provide any requested attributes
     4. Send it to the verifier endpoint contained in the challenge
     5. Store the received certificate chain on success
     6. Handle errors based on what went wrong
     
-    In addition, even more low-level access is possible by directly using Signum Supreme:
+    In addition, even more low-level access is possible by directly using Signum Supreme. The following example is
+    intentionally **signature-mode only**; it rejects hash challenges and requested attributes rather than accidentally
+    creating a proof with different semantics:
 
     ```kotlin
-    --8<-- "Readme-client-manual-lowlevel.kt:25:70"
+    --8<-- "Readme-client-manual-lowlevel.kt:31:82"
     ```
     
     1. Create an `AttestationClient` from a [Ktor](https://ktor.io/) client.
     2. Fetch the challenge
-    3. Create and configure a signer using Signum Supreme based on your demands  
+    3. Assert that this manual implementation supports the received challenge, then create and configure a signer using
+       Signum Supreme based on your demands
        This means that you can also override any client hints from the received challenge
     4. Don't forget to pass the nonce to enable attestation!
-    5. Create the CSR as desired
-    6. Send it to the verifier endpoint contained in the challenge
+    5. Create and sign the CSR as desired
+    6. Wrap it as `AttestationProof.Signed` and send it to the verifier endpoint contained in the challenge
     7. Store the received certificate chain on success
     8. Handle errors based on what went wrong
+
+    For new integrations, prefer `createAttestationProof`: it implements both authentication modes, canonical hash-input
+    construction, key matching expectations, and requested-attribute encoding. The deprecated CSR-only client functions
+    accept signature challenges without requested attributes only and fail explicitly otherwise.
 
 ## Beyond the Basics
 
@@ -456,15 +511,19 @@ On the back-end, however, attestation issues typically need to be analysed. Henc
 four callbacks to analyse challenge validation, attestation errors, and success (without side effects):
 
 ```kotlin
---8<-- "Readme-Backend-callbacks.kt:15:50"
+--8<-- "Readme-Backend-callbacks.kt:18:56"
 ```
 
-1. This is simply the CSR from the client, as in the minimal example
-2. `onChallengeValidated` is called after the CSR’s challenge binding was validated. It has the validated challenge as receiver and the CSR as parameter.
-3. `onPreAttestationError` is called in case of operational/internal errors, or if the attestation statement cannot
-   be extracted from a CSR. Different side-effect-free handling strategies can be employed based on error type.
+1. This is the `AttestationProof` from the client, as in the minimal example.
+2. `onChallengeValidated` is called after the proof's challenge binding was validated. It has the validated challenge as
+   receiver and the signed CSR or unsigned TBS CSR wrapper as parameter. Do not log challenge nonces.
+3. `onPreAttestationError` is called for challenge/extraction/operational failures and for new client-data validation
+   failures. `ClientDataValidation.reason` distinguishes authentication mismatch, ambiguous or malformed CSR structure,
+   hash binding, attested-key mismatch, and requested-attribute failures.
 4. At the end of `onPreAttestationError`, it is possible to return a custom error explanation to the client (can be null).
-5. `onAttestationError` is called if the attestation statement fails to verify. This includes an invalid bootloader lock state, wrong package identifier, etc.
+5. `onAttestationError` is called if the platform attestation statement fails to verify. This includes an invalid
+   bootloader lock state, wrong package identifier, nonce/hash mismatch, etc. An invalid CSR signature in signature mode
+   is also reported here.
    See [the dedicated error handling guide](errorhandling.md) for more details!
 6. This logs a debug statement that can be used to replicate and debug the attestation process. **Beware of privacy implications!** See the [Debugging](debugging.md) page.
 7. Again, a custom error message can be sent to the client
@@ -472,15 +531,17 @@ four callbacks to analyse challenge validation, attestation errors, and success 
    This can be useful for statistical analyses, for example.
 9. This is the certificate signing lambda, also having a fully verified attestation result as receiver.
    In contrast to `onAttestationSuccess`, it is not side-effect-free, but is expected to return a certificate chain, whose
-   leaf certifies the attested key. As such, it receives the fully verified CSR as a parameter.
+   leaf certifies the attested key. It receives the fully verified `AttestationProof`; extract its TBS CSR from the
+   signed or hashed subtype as needed.
 
 
 The step-by-step guide [above](#warden-supreme-step-by-step-guide) will cover most use cases perfectly well.
 While extensive configurations were also included alongside the basic ones, Warden Supreme is, in fact, more flexible:
 
 * Instead of always using the defaults, it is possible to specify challenge properties manually for each challenge issued
-* Key constraints need not be specified. In that case, it is up to the client to create a key that is desired by the back-end and sign a CSR manually.  
+* Key constraints need not be specified. In that case, it is up to the client to create a suitable key and construct the
+  authentication mode requested by the challenge manually.
   (This is still very smooth, as can be seen in the [API docs](../dokka/supreme-client/at.asitplus.attestation.supreme/index.html#110236803%2FFunctions%2F-1347999820).)
-* By default, a device identifier is always encoded into the CSR; this can be toggled.
+* By default, a generic device name is encoded into the TBS CSR on a best-effort basis; this can be toggled.
 
 For more details, refer to the API docs on the [verifier](../dokka/supreme-verifier/at.asitplus.attestation.supreme/-attestation-verifier/) and on the [client](../dokka/supreme-client/at.asitplus.attestation.supreme/-attestation-client/)!

--- a/docs/docs/integration/supreme.md
+++ b/docs/docs/integration/supreme.md
@@ -78,9 +78,9 @@ signature challenge.
 
 ### Requesting Client-Provided Attributes
 
-The verifier can place an `AttestableAttributes` schema in a challenge. It contains a dedicated attribute OID and an
-ordered list of `ToBeAttestedAttribute(name, type, required)` entries. The client callback receives that list and returns
-one `Primitive` per entry. Required values must be present; optional values can be `null`.
+The verifier can place a `CertificationRequestAttributeAttestationDescriptor` in a challenge. It contains a dedicated
+attribute OID and an ordered list of `AttributeAttestationDescriptor(name, type, required)` entries. The client callback
+receives that list and returns one `Primitive` per entry. Required values must be present; optional values can be `null`.
 
 These values are produced by the app, not independently certified by Android or Apple. Successful verification means the
 expected app supplied them and the selected authentication mode bound them into this ceremony.
@@ -303,7 +303,9 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
     Challenge nonces are sensitive replay-protection material. Treat them as bearer values for their short lifetime: do not log them, do not expose them across sessions or callers, serve them only over protected transport, and bind/rate-limit callers in your HTTP layer when your service needs that context.
     Map that exception at your HTTP layer to `429 Too Many Requests` and, if useful, a `Retry-After` header.
     The cache deliberately does not implement backoff; caller-aware rate limiting needs IP, account, tenant, or device context and should live outside Warden Supreme.
-    For horizontally scaled or high-volume deployments, use a distributed TTL-backed `ChallengeValidator` instead (Redis, for example).
+    For horizontally scaled or high-volume deployments, provide a distributed TTL-backed `AttestationChallengeValidator`
+    instead (Redis, for example). Its `validate(AttestationProof)` method handles both signed and hash-based proofs;
+    the deprecated `ChallengeValidator` supports signed CSRs only.
 
 ```kotlin
 --8<-- "Readme-Verifier-min.kt:3"

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -17,6 +17,22 @@ Warden Supreme consolidates
 and integrates them with [Signum](https://a-sit-plus.github.io/signum/), our Kotlin Multiplatform crypto/PKI library,
 into one attestation format and a single client and server API.
 **Creating an attestable, hardware-backed key comes down to a single line of client code.**
+Each challenge can require a signed proof of possession or hash-bind an unsigned TBS CSR, and can request typed
+application-provided attributes that are authenticated by either mode.
+
+The platform libraries underneath Warden Supreme answer whether an Android or Apple attestation artefact is valid.
+Warden Supreme supplies the substantially larger system around that decision that makes the difference between verifying
+an attestation artefact and a production-grade, ready-to-deploy solution:
+
+* Client-side hardware-key creation
+* Versioned challenge and proof protocol
+* Replay protection
+* Cross-platform policy
+* Key and application-data binding
+* Certificate issuance
+* Externalisable configuration
+* Stable error handling
+* **Production-prove, battle-tested platform workarounds**
 
 !!! tip inline end "Familiar with attestation?"
     **[Jump to the integration guide!](integration/supreme.md)**  

--- a/docs/docs/why-supreme.md
+++ b/docs/docs/why-supreme.md
@@ -4,8 +4,10 @@ If you only ever target one platform, you might be wondering:
 why not use [`android/keyattestation`](https://github.com/android/keyattestation) or
 [`veehaitch/devicecheck-appattest`](https://github.com/veehaitch/devicecheck-appattest) directly?
 
-Short answer: Warden Supreme is not a replacement for those libraries.
-It builds on top of them and provides a unified integration and policy layer around them.
+Those libraries are deliberately focused verification engines. Warden Supreme builds on them, but its scope is much
+larger: it provides the client ceremony, wire protocol, challenge lifecycle, cross-platform policy, key binding, optional
+proof of possession, application-data authentication, certificate issuance hooks, configuration, error semantics, and
+operational safeguards needed to turn platform attestation primitives into a deployable system.
 
 ## Quick Decision Guide
 
@@ -16,12 +18,17 @@ It builds on top of them and provides a unified integration and policy layer aro
 
 ## What Warden Supreme Adds
 
+!!! tip
+    See the [full comparison matrix](#comparison-matrix) to see how much added value Warden Supreme brings.
+
 The platform libraries deliberately stop at verification primitives. Warden Supreme adds the layer on top of them that
 you would otherwise write yourself:
 
 - Unified Back-end API and decision model shared across Android and iOS
 - Unified Client API shared across Android and iOS
 - Shared wire format and flow (`challenge` -> `attest` -> `certificate / error`)
+- Challenge-selected signed proof of possession or hash-bound data authentication, including typed required/optional
+  client-provided attributes
 - Built-in iOS key-attestation emulation to mirror Android-style key-binding semantics
 - One error and policy model instead of two independent verification stacks
 - Sane defaults and maintained workarounds for platform quirks, informed by years of production operation
@@ -44,8 +51,8 @@ production cohorts of over one million end-user devices across several services,
 Warden Supreme already supports externalising attestation configuration and wiring.
 Hence, policy can be managed outside independently of code and maintained deployment/environment specific.
 
-While upstreamed to the platform libraries, also hardcode very little wrt. policy, using them directly would still have
-you define, maintain, and evolve:
+The platform libraries intentionally hard-code little policy. When using them directly, you still need to define,
+maintain, and evolve:
 
 - a policy model structure,
 - a mapping from external configuration to runtime verifier settings,
@@ -81,40 +88,60 @@ See [Externalising Configuration](integration/config.md) for the actual policy f
 
 ## Comparison Matrix
 
-| Criterion                                       | Warden Supreme                                               | `android/keyattestation`                    | `veehaitch/devicecheck-appattest`                            |
-|-------------------------------------------------|--------------------------------------------------------------|---------------------------------------------|--------------------------------------------------------------|
-| Primary scope                                   | End-to-end Android+iOS attestation integration               | Android attestation verification primitives | iOS App Attest verification primitives                       |
-| Platform coverage                               | Android + iOS                                                | Android only                                | iOS only                                                     |
-| Unified server contract                         | Yes                                                          | No                                          | No                                                           |
-| Unified mobile client contract                  | Yes (integrated clients)                                     | No                                          | No                                                           |
-| Key-attestation semantics on iOS                | Built in (emulated key attestation)                          | Not applicable                              | Requires your own binding design around App Attest semantics |
-| Policy model                                    | Shared high-level policy with platform-specific config knobs | Android-specific only                       | iOS-specific only                                            |
-| Production-hardened defaults and quirk handling | Included and continuously maintained                         | You own this                                | You own this                                                 |
-| Externalised configuration support              | Included                                                     | You design and maintain it                  | You design and maintain it                                   |
-| Wire format and endpoint flow                   | Included and documented                                      | You design it                               | You design it                                                |
-| Multi-platform future-proofing                  | High                                                         | Low                                         | Low                                                          |
-| Integration effort                              | Lower for end-to-end flows                                   | Higher for full product integration         | Higher for full product integration                          |
+The below table compares library scope, not the quality of the underlying cryptographic verification. Warden Supreme delegates
+the platform-specific work to these libraries and adds the end-to-end system around it.
 
-## Android-Only: Why Not Just `android/keyattestation`?
+| Capability                                        | `android/keyattestation`                                       | `devicecheck-appattest`                              | Warden Supreme                                                                        |
+|---------------------------------------------------|----------------------------------------------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------|
+| Primary abstraction                               | Android certificate-chain verifier                             | Apple App Attest verifier                            | Complete mobile attestation and key-certification ceremony                            |
+| Unified API for Android and iOS                   | ❌                                                             | ❌                                                   | Yes, with shared challenge, result, and policy concepts                               |
+| Server-side verification                          | Android only                                                   | iOS only                                             | Android, iOS, or both from one verifier                                               |
+| Integrated mobile client                          | ❌                                                             | ❌                                                   | Kotlin Multiplatform Android/iOS client                                               |
+| Automated hardware-backed key creation            | ❌                                                             | ❌                                                   | Integrated with challenge-provided key requirements                                   |
+| iOS key-attestation semantics                     | ❌                                                             | App Attest primitive; binding design is caller-owned | App Attest is composed into Android-like key-attestation semantics                    |
+| Challenge creation                                | ❌                                                             | ❌                                                   | Issued by the verifier with nonce, validity, endpoint, policy, and app payload        |
+| Challenge expiry and replay protection            | Challenge checkers and an optional in-memory LRU are available | ❌                                                   | Bounded cache, one-time consumption, expiry, and pluggable persistence contract       |
+| Clock-drift handling                              | ❌                                                             | ❌                                                   | Integrated into challenge and attestation validity checks                             |
+| Client/server wire protocol                       | ❌                                                             | ❌                                                   | Versioned challenge, DER proof transport, and structured response model               |
+| Signed proof of possession                        | ❌                                                             | ❌                                                   | Built in through a signed PKCS#10 CSR                                                 |
+| Authentication without signing                    | ❌                                                             | ❌                                                   | Hash-bound TBS CSR through the platform attestation nonce                             |
+| Typed client-provided attested attributes         | ❌                                                             | ❌                                                   | Ordered required/optional attributes with ASN.1 type validation                       |
+| Binding application data to attestation           | Raw challenge checker available                                | Assertion challenge validator available              | Integrated into signed or hash-authenticated CSR contents                             |
+| Binding the claimed public key to the attestation | Exposes the attested public key                                | ❌                                                   | Mandatory verifier check in both authentication modes                                 |
+| CSR construction and validation                   | ❌                                                             | ❌                                                   | Canonical TBS CSR/CSR construction, structural validation, and ambiguity checks       |
+| Certificate issuance                              | ❌                                                             | ❌                                                   | Verified-result callback receives the authenticated request and issues a chain        |
+| Stable cross-platform result model                | Android-specific results                                       | iOS-specific exceptions/results                      | Unified success plus `TRUST`, `TIME`, `CONTENT`, and `INTERNAL` failures              |
+| Typed integration callbacks                       | Verification hooks                                             | Verification hooks                                   | Challenge, client-data, attestation, policy, success, and issuance callbacks          |
+| Additional service policy checks                  | ❌                                                             | ❌                                                   | First-class pre-issuance verification callback with structured failures               |
+| Android application identity policy               | Constraint primitives                                          | ❌                                                   | Package and signer policy in the unified configuration                                |
+| iOS application identity policy                   | ❌                                                             | App identity validation                              | Team, bundle, environment, receipt, and assertion policy in the unified configuration |
+| Android verified-boot policy                      | Parsed/constraint data available                               | ❌                                                   | OEM-only, mixed OEM/custom-ROM, or explicitly trusted custom-ROM policies             |
+| Remote Key Provisioning policy                    | Provisioning information is exposed                            | ❌                                                   | Can require RKP globally or per application and select appropriate roots              |
+| Android trust anchors                             | Google defaults or caller-provided anchors                     | ❌                                                   | Google, RKP, and custom roots with application-level policy                           |
+| Android revocation                                | Google revocation source/checking                              | ❌                                                   | Google plus composable HTTP, file, and custom revocation sources                      |
+| iOS assertions and counters                       | ❌                                                             | Assertion validation                                 | Exposed through Warden makoto with canonical persistence helpers                      |
+| iOS receipts                                      | ❌                                                             | Validation and exchange primitives                   | Integrated into Warden makoto policy and verification                                 |
+| External JSON/YAML configuration                  | ❌                                                             | ❌                                                   | Canonical serialisation for the complete verifier policy                              |
+| Spring Boot configuration                         | ❌                                                             | ❌                                                   | Dedicated integration module                                                          |
+| Hoplite configuration                             | ❌                                                             | ❌                                                   | Dedicated integration module                                                          |
+| Multiple apps and environments                    | Caller orchestration                                           | Caller orchestration                                 | Multiple Android/iOS app policies in one configuration                                |
+| Platform-quirk workarounds                        | Unsatisfactory in practice                                     | iOS verifier scope                                   | Cross-platform workarounds maintained from production device behaviour                |
+| Debuggable attestation failures                   | ❌ (only Android-specific result details)                      | ❌ (only iOS-specific exceptions)                    | Unified typed callbacks plus serialisable debug statements for offline analysis       |
+| End-to-end emulator coverage                      | ❌                                                             | ❌                                                   | Client-to-verifier Android emulator scenarios across auth and attribute combinations  |
+| Escape hatch for custom flows                     | Direct verifier API                                            | Direct verifier API                                  | Integrated Supreme API or lower-level makoto/roboto APIs                              |
 
-If your service is Android-only and you want full custom control, using Android-specific tooling directly can be reasonable.
-Yet Warden Supreme still pays off when you want:
+The difference is architectural: the upstream libraries answer “is this platform artefact valid?” Warden Supreme also
+answers “how is it requested, transported, bound to a key and application data, evaluated consistently across platforms,
+turned into a certificate, configured in production, and reported safely when anything fails?”
 
-- a ready-made, production-oriented verification flow instead of hand-rolled endpoint contracts,
-- a cleaner migration to iOS later without replacing your verifier architecture, or
-- shared policy and error handling across present and future platforms,
-- attestation logic that accounts for platform quirks and evolves with Android releases.
+The above table is more than just a marketing skit.
+It effectively means if you want to use vanilla DeviceCheck/App Attest or `android/keyattestation`, you'd end up implementing a good chunk of what Warden Supreme gives you from scratch.
+It won't work as well, and you'll hit the same walls we did, while developing Warden Supreme, and you'll end up re-doing much of the work that went into Warden Supreme.  
+How do we know? Warden Supreme is the culmination of doing precisely that multiple times.
 
-## iOS-Only: Why Not Just DeviceCheck/App Attest Helpers?
+In the end, we had three slightly different, slightly incompatible implementations with subtle rough edges in different places and incompatible wire formats and configuration
+mechanisms&hairsp;&mdash;&hairsp;even when already using Warden Supreme's predecessors, WARDEN and WARDEN-roboto.
 
-If your service is iOS-only, and you want to own all server/client wiring, using App Attest helpers directly can be reasonable.
-
-Warden Supreme still pays off when you want:
-
-- iOS key-binding semantics aligned with Android via built-in key-attestation emulation,
-- a consistent attestation lifecycle model without custom glue code, or
-- easier future expansion to Android with minimal conceptual churn,
-- attestation logic that accounts for platform quirks and evolves with iOS releases.
 
 ## FAQ
 

--- a/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
@@ -798,6 +798,7 @@ sealed class ChallengeValidationResult {
  * Hence, a certificate can be issued and the whole certificate chain (from newly issued certificate up to the CA)
  * shall be returned.
  */
+@Deprecated("To be removed in Warden Supreme 1.5", replaceWith = ReplaceWith("CertificateIssuerV2"))
 typealias CertificateIssuer = suspend AttestationResult.Verified.(Pkcs10CertificationRequest) -> CertificateChain
 
 /**


### PR DESCRIPTION
## PR 2/3 (Docs)

* **Selectable attestation-proof authentication and attested client attributes**
    * Add `DataAuthentication.Signature` (default) and `DataAuthentication.Hash` challenge modes.
    * Signature mode preserves the existing signed-PKCS#10 behaviour and proof-of-possession check.
    * Hash mode returns an unsigned TBS CSR and binds its version, subject, extensions, and non-proof attributes through
      a canonical DER hash used as the platform attestation nonce. It deliberately does not prove possession.
    * Always verify that the public key in the received TBS CSR matches the key proven by the platform attestation.
    * Add `AttestationProof` as the verifier/client transport abstraction and structurally decode its DER as either
      a complete CSR or TBS CSR. Hash algorithms remain challenge-owned and are never supplied with client transport.
      Deprecate CSR-only overloads; they reject hash authentication and requested attributes instead of silently changing
      behaviour.
    * Add ordered required/optional client-provided attributes using `AttestableAttributes`, `ToBeAttestedAttribute`,
      `PrimitiveType`, and ASN.1 codecs. Values are authenticated by either supported mode.
    * Move authentication selection from optional `KeyConstraints` into `AttestationChallenge`.
    * Add canonical `AttestationHashInput` conversion to and from TBS CSR data, excluding only the public key and exactly
      one attestation-proof attribute.
    * Reject authentication-mode mismatches, duplicate CSR attribute/extension OIDs, malformed extension requests,
      non-canonical attribute order, key mismatches, and missing or invalid requested attributes.
    * Route all new verifier validation failures through `onPreAttestationError` as typed
      `PreAttestationError.ClientDataValidation` values.
    * Add `dataAuthentication` and human-readable `attestableAttributes` support to `SupremeConfiguration` JSON/YAML.
    * Expand client, verifier, property, and Android-emulator end-to-end coverage for both authentication modes and
      required/optional attribute combinations.
* Add Supreme dependency to `supreme-common`
* Dependency Updates
    * KeyAttestation [47f970d044ae4da7b00da068e7e1a4e952b0fd2f](https://github.com/android/keyattestation/commit/47f970d044ae4da7b00da068e7e1a4e952b0fd2f)
    * AGP 9.1.1
    * Gradle 9.6.1
    * Kotlin 2.4.10
    * TestBalloon 1.0.1
    * TestBalloon Addon 0.16.0