### PR TITLE
Fix/compat test

### DIFF
--- a/.github/workflows/test-supreme-102-compatibility.yml
+++ b/.github/workflows/test-supreme-102-compatibility.yml
@@ -31,9 +31,9 @@ jobs:
 
       - name: Compile verifier and 1.0.2 client
         run: |
-          cp 102/supreme/verifier/src/jvmTest/kotlin/main.kt supreme/verifier/src/jvmTest/kotlin/main.kt
+          cp release-1.0.2/supreme/verifier/src/jvmTest/kotlin/main.kt supreme/verifier/src/jvmTest/kotlin/main.kt
           ./gradlew :supreme-verifier:jvmTestClasses
-          ./102/gradlew -p 102 :supreme-client:createAndroidDeviceTestApkListingFileRedirect
+          ./release-1.0.2/gradlew -p release-1.0.2 :supreme-client:createAndroidDeviceTestApkListingFileRedirect
 
       - name: Run 1.0.2 client against current verifier
         run: |
@@ -48,7 +48,7 @@ jobs:
           curl --fail --retry 60 --retry-connrefused --retry-delay 1 \
             http://localhost:8080/api/v1/challenge >/dev/null
 
-          ./102/gradlew -p 102 pixelAVDAndroidDeviceTest --info
+          ./release-1.0.2/gradlew -p release-1.0.2 pixelAVDAndroidDeviceTest --info
           wait "$verifier_pid"
 
       - name: Test report
@@ -56,6 +56,6 @@ jobs:
         if: success() || failure()
         with:
           name: Warden Supreme 1.0.2 Compatibility Tests
-          path: 102/supreme/client/build/outputs/androidTest-results/managedDevice/**/pixelAVD/TEST*.xml,supreme/**/build/test-results/**/TEST*.xml
+          path: release-1.0.2/supreme/client/build/outputs/androidTest-results/managedDevice/**/pixelAVD/TEST*.xml,supreme/**/build/test-results/**/TEST*.xml
           reporter: java-junit
           use-actions-summary: true

--- a/.github/workflows/test-supreme-102-compatibility.yml
+++ b/.github/workflows/test-supreme-102-compatibility.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Compile verifier and 1.0.2 client
         run: |
+          git checkout 1.0.2 supreme/verifier/src/jvmTest/kotlin/main.kt
           ./gradlew :supreme-verifier:jvmTestClasses
           ./102/gradlew -p 102 :supreme-client:createAndroidDeviceTestApkListingFileRedirect
 

--- a/.github/workflows/test-supreme-102-compatibility.yml
+++ b/.github/workflows/test-supreme-102-compatibility.yml
@@ -1,0 +1,60 @@
+name: Test Supreme 1.0.2 Client Compatibility
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Accept Android SDK licences
+        run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+      - name: Install Android SDK 30
+        run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install platform-tools "platforms;android-30" "build-tools;30.0.0" "system-images;android-30;default;x86_64"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Compile verifier and 1.0.2 client
+        run: |
+          ./gradlew :supreme-verifier:jvmTestClasses
+          ./102/gradlew -p 102 :supreme-client:createAndroidDeviceTestApkListingFileRedirect
+
+      - name: Run 1.0.2 client against current verifier
+        run: |
+          set -euo pipefail
+
+          SUPREME_ENDTOENDTEST=true \
+          TESTBALLOON_INCLUDE_PATTERNS=at.asitplus.attestation.supreme.TestEnv* \
+            ./gradlew :supreme-verifier:jvmTest > verifier.log 2>&1 &
+          verifier_pid=$!
+          trap 'kill "$verifier_pid" 2>/dev/null || true' EXIT
+
+          curl --fail --retry 60 --retry-connrefused --retry-delay 1 \
+            http://localhost:8080/api/v1/challenge >/dev/null
+
+          ./102/gradlew -p 102 pixelAVDAndroidDeviceTest --info
+          wait "$verifier_pid"
+
+      - name: Test report
+        uses: dorny/test-reporter@v2
+        if: success() || failure()
+        with:
+          name: Warden Supreme 1.0.2 Compatibility Tests
+          path: 102/supreme/client/build/outputs/androidTest-results/managedDevice/**/pixelAVD/TEST*.xml,supreme/**/build/test-results/**/TEST*.xml
+          reporter: java-junit
+          use-actions-summary: true

--- a/.github/workflows/test-supreme-102-compatibility.yml
+++ b/.github/workflows/test-supreme-102-compatibility.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Compile verifier and 1.0.2 client
         run: |
-          git checkout 1.0.2 supreme/verifier/src/jvmTest/kotlin/main.kt
+          cp 102/supreme/verifier/src/jvmTest/kotlin/main.kt supreme/verifier/src/jvmTest/kotlin/main.kt
           ./gradlew :supreme-verifier:jvmTestClasses
           ./102/gradlew -p 102 :supreme-client:createAndroidDeviceTestApkListingFileRedirect
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,5 +11,5 @@
 	path = dependencies/http-proxy
 	url = https://github.com/zk-123/http-proxy.git
 [submodule "102"]
-	path = 102
+	path = release-1.0.2
 	url = ../warden-supreme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "dependencies/http-proxy"]
 	path = dependencies/http-proxy
 	url = https://github.com/zk-123/http-proxy.git
+[submodule "102"]
+	path = 102
+	url = ../warden-supreme.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ this changelog also includes the original WARDEN changelog.
     * Add `dataAuthentication` and human-readable `toBeAttestedAttributes` support to `SupremeConfiguration` JSON/YAML.
     * Expand client, verifier, property, and Android-emulator end-to-end coverage for both authentication modes and
       required/optional attribute combinations.
+    * Bump ChallengeVersion to 3, but still transmit 2, of DataAuthentication.Signature is used without any requested to-be-attested attributes
 * Add Supreme dependency to `supreme-common`
 * Dependency Updates
     * KeyAttestation [47f970d044ae4da7b00da068e7e1a4e952b0fd2f](https://github.com/android/keyattestation/commit/47f970d044ae4da7b00da068e7e1a4e952b0fd2f)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,3 +11,6 @@
     * Or: Set the environment vatriable `NO_PRIVATE_TEST_DATA` to `true`
 * To publish locally: `publishAllpublicationsToMavenLocal`
 * See Project structure in the official documentation for info on which module does what
+
+If you change behaviour in a braking way or `AttestationChallenge` changes shape, bump the `CURRENT_VERSION`and check if
+older versin can still be used in some scenarios for improved compat

--- a/supreme/common/src/commonMain/kotlin/AttestationChallenge.kt
+++ b/supreme/common/src/commonMain/kotlin/AttestationChallenge.kt
@@ -13,11 +13,7 @@ import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequest
 import at.asitplus.signum.indispensable.pki.TbsCertificationRequest
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.serializers.TimeZoneSerializer
-import kotlinx.serialization.EncodeDefault
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
 import kotlin.time.Duration
 import kotlin.time.Instant
 
@@ -207,7 +203,7 @@ private constructor(
         attestationEndpoint = attestationEndpoint,
         proofOID = proofOID,
         genericDeviceNameOID = genericDeviceNameOID,
-        version = CURRENT_VERSION,
+        version = if (dataAuth == DataAuthentication.Signature && toBeAttestedAttributes == null) 2 else CURRENT_VERSION,
         keyConstraints = keyConstraints,
         additionalPayload = additionalPayload,
         transientData = transientData,
@@ -294,7 +290,7 @@ private constructor(
     data class AttributeAttestationDescriptor(val name: String, val type: PrimitiveType, val required: Boolean = true)
 
     companion object {
-        const val CURRENT_VERSION: Int = 2
+        const val CURRENT_VERSION: Int = 3
     }
 }
 

--- a/supreme/common/src/commonMain/kotlin/AttestationChallenge.kt
+++ b/supreme/common/src/commonMain/kotlin/AttestationChallenge.kt
@@ -13,6 +13,8 @@ import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequest
 import at.asitplus.signum.indispensable.pki.TbsCertificationRequest
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.serializers.TimeZoneSerializer
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Transient
@@ -52,6 +54,7 @@ import kotlin.time.Instant
  *
  * @throws IllegalArgumentException If the [nonce] exceeds 128 bytes or is shorter than 4 bytes
  */
+@OptIn(ExperimentalSerializationApi::class)
 @ConsistentCopyVisibility
 @Serializable
 data class AttestationChallenge
@@ -144,6 +147,7 @@ private constructor(
      * Ordered client-provided values to bind to the attestation. The values are stored under [CertificationRequestAttributeAttestationDescriptor.oid]
      * and decoded according to [CertificationRequestAttributeAttestationDescriptor.attributes].
      */
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
     val toBeAttestedAttributes: CertificationRequestAttributeAttestationDescriptor? = null,
 
     /**
@@ -151,6 +155,7 @@ private constructor(
      * private key; [DataAuthentication.Hash] binds the data through the platform attestation nonce without signing.
      * @see DataAuthentication
      */
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
     val dataAuth: DataAuthentication = DataAuthentication.Signature,
 
     ) {

--- a/supreme/common/src/jvmTest/kotlin/AttestationChallengeNonceTest.kt
+++ b/supreme/common/src/jvmTest/kotlin/AttestationChallengeNonceTest.kt
@@ -1,6 +1,9 @@
 import at.asitplus.attestation.supreme.AttestationChallenge
+import at.asitplus.attestation.supreme.DataAuthentication
+import at.asitplus.attestation.supreme.PrimitiveType
 import at.asitplus.attestation.supreme.WardenDefaults
-import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.signum.indispensable.Digest
+import at.asitplus.testballoon.matrix.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -12,6 +15,18 @@ import kotlin.time.Instant
 private val challengeJson = Json {
     encodeDefaults = true
 }
+
+private val requestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
+    WardenDefaults.OIDs.DEVICE_NAME,
+    listOf(AttestationChallenge.AttributeAttestationDescriptor("value", PrimitiveType.STRING)),
+)
+
+private data class VersionCase(
+    val name: String,
+    val dataAuth: DataAuthentication,
+    val requestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor?,
+    val expectedVersion: Int,
+)
 
 val AttestationChallengeNonceTest by matrixSuite {
     "nonce length accepts inclusive 4 to 128 byte boundary" {
@@ -51,13 +66,36 @@ val AttestationChallengeNonceTest by matrixSuite {
         encoded shouldNotContain "\"toBeAttestedAttributes\""
         encoded shouldNotContain "\"dataAuth\""
     }
+
+    data(
+        "version reflects requested features",
+        listOf(
+            VersionCase("signature without attributes", DataAuthentication.Signature, null, 2),
+            VersionCase("signature with attributes", DataAuthentication.Signature, requestedAttributes, 3),
+            VersionCase("hash without attributes", DataAuthentication.Hash(Digest.SHA256), null, 3),
+            VersionCase("hash with attributes", DataAuthentication.Hash(Digest.SHA256), requestedAttributes, 3),
+        ),
+        nameFn = { _, case -> case.name },
+    ) test { case ->
+        challengeWithNonce(
+            nonce = ByteArray(4),
+            dataAuth = case.dataAuth,
+            requestedAttributes = case.requestedAttributes,
+        ).version shouldBe case.expectedVersion
+    }
 }
 
-private fun challengeWithNonce(nonce: ByteArray) = AttestationChallenge(
+private fun challengeWithNonce(
+    nonce: ByteArray,
+    dataAuth: DataAuthentication = DataAuthentication.Signature,
+    requestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+) = AttestationChallenge(
     issuedAt = Instant.fromEpochMilliseconds(0),
     validity = 5.seconds,
     timeZone = null,
     nonce = nonce,
     attestationEndpoint = "https://example.invalid/attest",
     proofOID = WardenDefaults.OIDs.ATTESTATION_PROOF,
+    toBeAttestedAttributes = requestedAttributes,
+    dataAuth = dataAuth,
 )

--- a/supreme/common/src/jvmTest/kotlin/AttestationChallengeNonceTest.kt
+++ b/supreme/common/src/jvmTest/kotlin/AttestationChallengeNonceTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.testballoon.matrix.matrixSuite
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
@@ -39,6 +40,16 @@ val AttestationChallengeNonceTest by matrixSuite {
         shouldThrow<IllegalArgumentException> {
             challengeJson.decodeFromString(AttestationChallenge.serializer(), encodedWithShortNonce)
         }.message shouldContain "at least 4 bytes"
+    }
+
+    "new default fields stay absent for old clients" {
+        val encoded = challengeJson.encodeToString(
+            AttestationChallenge.serializer(),
+            challengeWithNonce(ByteArray(4)),
+        )
+
+        encoded shouldNotContain "\"toBeAttestedAttributes\""
+        encoded shouldNotContain "\"dataAuth\""
     }
 }
 

--- a/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
@@ -401,7 +401,8 @@ constructor(
                 )
             }
         }
-        return if (attributes.map { it.encodeToTlv() } != Asn1.SetOf { attributes.forEach { +it } }.toList()) {
+        return if (challenge.dataAuth != DataAuthentication.Signature && (attributes.map { it.encodeToTlv() } != Asn1.SetOf { attributes.forEach { +it } }
+                .toList())) {
             clientDataValidationFailure(
                 type = Type.CONTENT,
                 reason = PreAttestationError.ClientDataValidation.Reason.NON_CANONICAL_CSR_ATTRIBUTE_ORDER,

--- a/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierOidUniquenessTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/AttestationVerifierOidUniquenessTest.kt
@@ -2,6 +2,7 @@
 
 package at.asitplus.attestation.supreme
 
+import at.asitplus.signum.indispensable.Digest
 import at.asitplus.signum.indispensable.asn1.Asn1String
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.asn1.encoding.Asn1
@@ -112,7 +113,10 @@ val AttestationVerifierOidUniquenessTest by matrixSuite {
     test("non-canonical attribute order is rejected as CONTENT") {
         val fixture = generateAndroidFixture()
         val verifier = fixture.verifier(fixture.trustedConfig())
-        val challenge = verifier.issueChallenge(attestationEndpoint)
+        val challenge = verifier.issueChallenge(
+            attestationEndpoint,
+            dataAuth = DataAuthentication.Hash(Digest.SHA256),
+        )
         val proof = Pkcs10CertificationRequestAttribute(
             challenge.proofOID,
             Asn1String.UTF8(fixture.fake.attestationJson()).encodeToTlv(),
@@ -128,7 +132,7 @@ val AttestationVerifierOidUniquenessTest by matrixSuite {
 
         var callbackError: PreAttestationError.ClientDataValidation? = null
         val failure = verifier.verifyAttestation(
-            AttestationProof.Signed(csr),
+            AttestationProof.Hashed(csr.tbsCsr),
             onPreAttestationError = {
                 callbackError = shouldBeInstanceOf<PreAttestationError.ClientDataValidation>()
                 "callback"

--- a/supreme/verifier/src/jvmTest/kotlin/TimeOffsetTests.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/TimeOffsetTests.kt
@@ -11,7 +11,12 @@ import de.infix.testBalloon.framework.core.testScope
 import at.asitplus.testballoon.matrix.*
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
-import kotlin.random.Random
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.frequency
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.withEdgecases
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -20,112 +25,76 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toKotlinDuration
 
+private data class TimeOffsetCase(val offset: Duration?, val validity: Duration?)
+
+private val offsetArb: Arb<Duration?> = Arb.frequency(
+    // This broad conversion caught an Android configuration bug, so keep it alongside the finer-grained durations.
+    10 to Arb.int().map { catchingUnwrapped { it.seconds }.getOrNull() },
+    10 to Arb.int().map { it.seconds },
+    10 to Arb.int().map { it.milliseconds },
+    10 to Arb.int().map { it.nanoseconds },
+).withEdgecases(5.minutes, Duration.ZERO, null)
+
+private val validityArb: Arb<Duration?> = Arb.int(0..Int.MAX_VALUE).map { it.seconds }
+private val timeOffsetCaseArb = Arb.bind(offsetArb, validityArb, ::TimeOffsetCase)
+
 val TimeOffsetTest by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEnabled = true, timeout = 15.minutes) }) {
+    compact("makoto vs bare")- {
+        property(timeOffsetCaseArb, iterations = 2150) test { (offset, validity) ->
+            val expectedValidity =
+                validity ?: (ReceiptValidator.APPLE_RECOMMENDED_MAX_AGE.toKotlinDuration() + Makoto.DEFAULT_TIME_OFFSET)
+            val expectedOffset = offset ?: Makoto.DEFAULT_TIME_OFFSET
 
-    val rands = Array<Duration?>(10) {
-        //There are limits to durations, and this will mostly be infinities, but it caught an Android config bug, so it stays
-        catchingUnwrapped { Random.nextInt().seconds }.getOrNull()
-    } + Array<Duration?>(10) {
-        //long durations
-        Random.nextInt().seconds
-    } + Array<Duration?>(10) {
-        //shorter ones
-        Random.nextInt().milliseconds
-    } + Array<Duration?>(10) {
-        //shorter ones
-        Random.nextInt().nanoseconds
-    }
-    "makoto vs bare" - {
-        data("offsets", listOf(
-            5.minutes, Duration.ZERO, null as Duration?, *rands,
-        )) - { offset ->
+            val clk = FixedTimeClock(0)
+            val clkConfig = object : SupremeConfiguration.Clock {
+                override val timeSource: Clock
+                    get() = clk
+            }
 
-            //we only have seconds precision here
-            data("validities", listOf(
-                *Array<Duration?>(50) { Random.nextInt(0, Int.MAX_VALUE).seconds },
-            )) - { validity ->
+            val androidAttestationConfiguration = if (validity != null) AndroidAttestationConfiguration(
+                AndroidAttestationConfiguration.AppData("foo", setOf(byteArrayOf())),
+                attestationStatementValiditySeconds = expectedValidity.inWholeSeconds,
+            ) else AndroidAttestationConfiguration(
+                AndroidAttestationConfiguration.AppData("foo", setOf(byteArrayOf())),
+            )
+            val iosAttestationConfiguration = if (validity != null) IosAttestationConfiguration(
+                IosAttestationConfiguration.AppData("1234567890", "baz"),
+                attestationStatementValiditySeconds = expectedValidity.inWholeSeconds,
+            ) else IosAttestationConfiguration(
+                IosAttestationConfiguration.AppData("1234567890", "baz"),
+            )
 
-                val expectedValidity =
-                    validity
-                        ?: (ReceiptValidator.APPLE_RECOMMENDED_MAX_AGE.toKotlinDuration() + Makoto.DEFAULT_TIME_OFFSET)
+            val makoto = if (offset != null) Makoto(
+                androidAttestationConfiguration,
+                iosAttestationConfiguration,
+                clock = clk,
+                verificationTimeOffset = expectedOffset,
+            ) else Makoto(
+                androidAttestationConfiguration,
+                iosAttestationConfiguration,
+                clock = clk,
+            )
+            val expectedIssuedAt = clk.now() - makoto.verificationTimeOffset
 
-                val expectedOffset = offset ?: Makoto.DEFAULT_TIME_OFFSET
+            withClue("Offset for $offset") { makoto.verificationTimeOffset shouldBe expectedOffset }
+            withClue("Validity for $validity") { makoto.shortestValidityDuration shouldBe expectedValidity }
 
-                val clk = FixedTimeClock(0)
-                val clkConfig = object : SupremeConfiguration.Clock {
-                    override val timeSource: Clock
-                        get() = clk
-                }
-
-                val androidAttestationConfiguration = if (validity != null) AndroidAttestationConfiguration(
-                    AndroidAttestationConfiguration.AppData(
-                        "foo",
-                        setOf(byteArrayOf())
-                    ),
-                    attestationStatementValiditySeconds = expectedValidity.inWholeSeconds
-                ) else AndroidAttestationConfiguration(
-                    AndroidAttestationConfiguration.AppData(
-                        "foo",
-                        setOf(byteArrayOf())
+            listOf(
+                AttestationVerifier(makoto),
+                AttestationVerifier(
+                    SupremeConfiguration(
+                        androidAttestationConfiguration,
+                        iosAttestationConfiguration,
+                        clkConfig,
+                        verificationTimeOffset = expectedOffset,
                     )
-                )
-                val iosAttestationConfiguration = if (validity != null) IosAttestationConfiguration(
-                    IosAttestationConfiguration.AppData(
-                        "1234567890",
-                        "baz"
-                    ),
-                    attestationStatementValiditySeconds = expectedValidity.inWholeSeconds
-                ) else IosAttestationConfiguration(
-                    IosAttestationConfiguration.AppData(
-                        "1234567890",
-                        "baz"
-                    )
-                )
-
-
-                val makoto = if (offset != null) Makoto(
-                    androidAttestationConfiguration,
-                    iosAttestationConfiguration,
-                    clock = clk,
-                    verificationTimeOffset = expectedOffset
-                )
-                else Makoto(
-                    androidAttestationConfiguration,
-                    iosAttestationConfiguration,
-                    clock = clk,
-                )
-
-                val expectedIssuedAt = clk.now() - makoto.verificationTimeOffset
-
-
-                //we verify makoto functionality here and not separately, as the verifier is tightly tied to it
-                //hence, it makes sense to contain these tests here
-                "makoto config checks" {
-                    withClue("Offset for $offset") { makoto.verificationTimeOffset shouldBe expectedOffset }
-                    withClue("Validity for $validity") { makoto.shortestValidityDuration shouldBe expectedValidity }
-                }
-
-
-                data(
-                    "verifiers",
-                    mapOf(
-                        "makoto" to AttestationVerifier(makoto),
-                        "bare" to AttestationVerifier(
-                            SupremeConfiguration(
-                                androidAttestationConfiguration,
-                                iosAttestationConfiguration,
-                                clkConfig,
-                                verificationTimeOffset = expectedOffset,
-                            )
-                        )
-                    ).values
-                ) test { verifier ->
-                    verifier.nonceValidity shouldBe expectedValidity
-                    verifier.issueChallenge("").let {
-                        withClue("Issued at") { it.issuedAt shouldBe expectedIssuedAt }
-                        withClue("Validity") { it.validity shouldBe expectedValidity }
-                        withClue("Valid until") { it.validUntil shouldBe expectedIssuedAt + expectedValidity }
-                    }
+                ),
+            ).forEach { verifier ->
+                verifier.nonceValidity shouldBe expectedValidity
+                verifier.issueChallenge("").let {
+                    withClue("Issued at") { it.issuedAt shouldBe expectedIssuedAt }
+                    withClue("Validity") { it.validity shouldBe expectedValidity }
+                    withClue("Valid until") { it.validUntil shouldBe expectedIssuedAt + expectedValidity }
                 }
             }
         }

--- a/supreme/verifier/src/jvmTest/kotlin/main.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/main.kt
@@ -6,10 +6,8 @@ import at.asitplus.attestation.android.AndroidAttestationConfiguration
 import at.asitplus.attestation.android.TrustedRoot
 import at.asitplus.attestation.android.parseHex
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.Digest
 import at.asitplus.signum.indispensable.asn1.Asn1String
 import at.asitplus.signum.indispensable.asn1.Asn1Time
-import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.pki.AttributeTypeAndValue
 import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequest
 import at.asitplus.signum.indispensable.pki.RelativeDistinguishedName
@@ -35,32 +33,6 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.ExperimentalUuidApi
-
-private data class AuthenticationScenario(
-    val authentication: DataAuthentication,
-    val expectedAttributes: List<Primitive>?,
-)
-
-private val authenticationScenarios = mapOf(
-    "signed-no-attributes" to AuthenticationScenario(DataAuthentication.Signature, null),
-    "hashed-no-attributes" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), null),
-    "signed-optional-present" to AuthenticationScenario(DataAuthentication.Signature, listOf("required", 42)),
-    "signed-optional-omitted" to AuthenticationScenario(DataAuthentication.Signature, listOf("required", null)),
-    "hashed-optional-present" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf("required", 42)),
-    "hashed-optional-omitted" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf("required", null)),
-    "signed-required-omitted" to AuthenticationScenario(DataAuthentication.Signature, listOf(null, 42)),
-    "hashed-required-omitted" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf(null, 42)),
-    "signed-all-omitted" to AuthenticationScenario(DataAuthentication.Signature, listOf(null, null)),
-    "hashed-all-omitted" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf(null, null)),
-)
-
-private val requestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
-    ObjectIdentifier("1.3.6.1.4.1.60387.1"),
-    listOf(
-        AttestationChallenge.AttributeAttestationDescriptor("required", PrimitiveType.STRING),
-        AttestationChallenge.AttributeAttestationDescriptor("optional", PrimitiveType.INT, required = false),
-    ),
-)
 
 @OptIn(ExperimentalStdlibApi::class, ExperimentalUuidApi::class)
 val TestEnv by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEnabled = false) }) {
@@ -108,56 +80,6 @@ val TestEnv by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEn
                     })
             )
 
-            suspend fun verify(
-                proof: AttestationProof,
-                scenario: AuthenticationScenario,
-            ) = attestationValidator.verifyAttestation(
-                proof,
-                onPreAttestationError = {
-                    val msg = throwable?.message ?: ""
-                    println(msg)
-                    msg
-                },
-                onAttestationError = { statement ->
-                    println(statement.serializeCompact())
-                    statement.serializeCompact()
-                },
-                additionalVerifications = { received, _ ->
-                    val actual = toBeAttestedAttributes?.let { requested ->
-                        val tbsCsr = received.tbsCsr
-                        val encoded = tbsCsr.attributes.singleOrNull { it.oid == requested.oid }
-                            ?.value?.singleOrNull()?.asSequence()
-                        AttestedAttributes(encoded).parsedAttributesBy(this)
-                    }
-                    if (actual == scenario.expectedAttributes) null
-                    else AttestationResponse.Failure(
-                        AttestationResponse.Failure.Type.CONTENT,
-                        "Expected ${scenario.expectedAttributes}, got $actual",
-                    )
-                },
-                certificateIssuer = { received ->
-                    val tbsCsr = received.tbsCsr
-                    println("Successfully attested device ${tbsCsr.deviceNameForOid(attestationValidator.genericDeviceNameOID ?: WardenDefaults.OIDs.DEVICE_NAME)}")
-                    Signer.Ephemeral { ec { } }.getOrThrow().let { signer ->
-                        signer.sign(
-                            TbsCertificate(
-                                serialNumber = Random.nextBytes(32),
-                                publicKey = tbsCsr.publicKey,
-                                signatureAlgorithm = signer.signatureAlgorithm.toX509SignatureAlgorithm().getOrThrow(),
-                                validFrom = Asn1Time(Clock.System.now()),
-                                validUntil = Asn1Time(Clock.System.now() + 10.days),
-                                issuerName = listOf(
-                                    RelativeDistinguishedName(
-                                        AttributeTypeAndValue.CommonName(Asn1String.UTF8("WARDEN Supreme"))
-                                    )
-                                ),
-                                subjectName = tbsCsr.subjectName,
-                            )
-                        ).map { listOf(it) }.getOrThrow()
-                    }
-                },
-            )
-
 
             val server = embeddedServer(Netty, port = 8080) {
                 install(ContentNegotiation) { json() }
@@ -180,41 +102,56 @@ val TestEnv by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEn
 
 
                     }
-                    get("$ENDPOINT_CHALLENGE/{scenario}") {
-                        val scenarioName = requireNotNull(call.parameters["scenario"])
-                        val scenario = requireNotNull(authenticationScenarios[scenarioName])
-                        call.respond(
-                            attestationValidator.issueChallenge(
-                                "$ENDPOINT_ATTEST/$scenarioName",
-                                timeZone = TimeZone.currentSystemDefault(),
-                                keyConstraints = WardenDefaults.KeyConstraints.p256Signer,
-                                toBeAttestedAttributes = scenario.expectedAttributes?.let { requestedAttributes },
-                                dataAuth = scenario.authentication,
-                            )
-                        )
-                    }
                     post(PATH_ATTEST) {
                         val src = call.receive<ByteArray>()
                         test("Got Challenge") {}
-                        call.respond(
-                            verify(
-                                AttestationProof.Signed(Pkcs10CertificationRequest.decodeFromDer(src)),
-                                AuthenticationScenario(DataAuthentication.Signature, null),
-                            )
-                        )
-                    }
-                    post("$PATH_ATTEST/{scenario}") {
-                        val scenarioName = requireNotNull(call.parameters["scenario"])
-                        val scenario = requireNotNull(authenticationScenarios[scenarioName])
-                        val src = call.receive<ByteArray>()
-                        val proof = AttestationProof.decodeFromDer(src).getOrThrow()
-                        call.respond(verify(proof, scenario))
+
+
+                        val resp =
+                            attestationValidator.verifyAttestation(
+                                Pkcs10CertificationRequest.decodeFromDer(src),
+                                onPreAttestationError = {
+                                    val msg = throwable?.message ?: ""
+                                    println(msg)
+                                    msg
+                                },
+                                onAttestationError = { stmt ->
+                                    println(stmt.serializeCompact())
+                                    stmt.serializeCompact()
+                                }) { csr ->
+                                println("Successfully attested device ${csr.deviceNameForOid(attestationValidator.genericDeviceNameOID ?: WardenDefaults.OIDs.DEVICE_NAME)}")
+                                Signer.Ephemeral {
+                                    ec { }
+                                }.getOrThrow().let { signer ->
+                                    signer.sign(
+                                        TbsCertificate(
+                                            serialNumber = Random.nextBytes(32),
+                                            publicKey = csr.tbsCsr.publicKey,
+                                            signatureAlgorithm = signer.signatureAlgorithm.toX509SignatureAlgorithm()
+                                                .getOrThrow(),
+                                            validFrom = Asn1Time(Clock.System.now()),
+                                            validUntil = Asn1Time(Clock.System.now() + 10.days),
+                                            issuerName = listOf(
+                                                RelativeDistinguishedName(
+                                                    AttributeTypeAndValue.CommonName(
+                                                        Asn1String.UTF8(
+                                                            "WARDEN Supreme"
+                                                        )
+                                                    )
+                                                )
+                                            ),
+                                            subjectName = csr.tbsCsr.subjectName,
+                                        )
+                                    ).map { listOf(it) }.getOrThrow()
+                                }
+                            }
+                        call.respond(resp)
                     }
 
                 }
             }.start(wait = false)
 
-            val timeout = 15.minutes
+            val timeout = 5.minutes
             println("KTOR server started!")
             println("   Waiting $timeout before auto-shutdown!")
             val before = Clock.System.now()

--- a/supreme/verifier/src/jvmTest/kotlin/main.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/main.kt
@@ -6,8 +6,10 @@ import at.asitplus.attestation.android.AndroidAttestationConfiguration
 import at.asitplus.attestation.android.TrustedRoot
 import at.asitplus.attestation.android.parseHex
 import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.Digest
 import at.asitplus.signum.indispensable.asn1.Asn1String
 import at.asitplus.signum.indispensable.asn1.Asn1Time
+import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.pki.AttributeTypeAndValue
 import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequest
 import at.asitplus.signum.indispensable.pki.RelativeDistinguishedName
@@ -33,6 +35,32 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.ExperimentalUuidApi
+
+private data class AuthenticationScenario(
+    val authentication: DataAuthentication,
+    val expectedAttributes: List<Primitive>?,
+)
+
+private val authenticationScenarios = mapOf(
+    "signed-no-attributes" to AuthenticationScenario(DataAuthentication.Signature, null),
+    "hashed-no-attributes" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), null),
+    "signed-optional-present" to AuthenticationScenario(DataAuthentication.Signature, listOf("required", 42)),
+    "signed-optional-omitted" to AuthenticationScenario(DataAuthentication.Signature, listOf("required", null)),
+    "hashed-optional-present" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf("required", 42)),
+    "hashed-optional-omitted" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf("required", null)),
+    "signed-required-omitted" to AuthenticationScenario(DataAuthentication.Signature, listOf(null, 42)),
+    "hashed-required-omitted" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf(null, 42)),
+    "signed-all-omitted" to AuthenticationScenario(DataAuthentication.Signature, listOf(null, null)),
+    "hashed-all-omitted" to AuthenticationScenario(DataAuthentication.Hash(Digest.SHA256), listOf(null, null)),
+)
+
+private val requestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
+    ObjectIdentifier("1.3.6.1.4.1.60387.1"),
+    listOf(
+        AttestationChallenge.AttributeAttestationDescriptor("required", PrimitiveType.STRING),
+        AttestationChallenge.AttributeAttestationDescriptor("optional", PrimitiveType.INT, required = false),
+    ),
+)
 
 @OptIn(ExperimentalStdlibApi::class, ExperimentalUuidApi::class)
 val TestEnv by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEnabled = false) }) {
@@ -80,6 +108,56 @@ val TestEnv by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEn
                     })
             )
 
+            suspend fun verify(
+                proof: AttestationProof,
+                scenario: AuthenticationScenario,
+            ) = attestationValidator.verifyAttestation(
+                proof,
+                onPreAttestationError = {
+                    val msg = throwable?.message ?: ""
+                    println(msg)
+                    msg
+                },
+                onAttestationError = { statement ->
+                    println(statement.serializeCompact())
+                    statement.serializeCompact()
+                },
+                additionalVerifications = { received, _ ->
+                    val actual = toBeAttestedAttributes?.let { requested ->
+                        val tbsCsr = received.tbsCsr
+                        val encoded = tbsCsr.attributes.singleOrNull { it.oid == requested.oid }
+                            ?.value?.singleOrNull()?.asSequence()
+                        AttestedAttributes(encoded).parsedAttributesBy(this)
+                    }
+                    if (actual == scenario.expectedAttributes) null
+                    else AttestationResponse.Failure(
+                        AttestationResponse.Failure.Type.CONTENT,
+                        "Expected ${scenario.expectedAttributes}, got $actual",
+                    )
+                },
+                certificateIssuer = { received ->
+                    val tbsCsr = received.tbsCsr
+                    println("Successfully attested device ${tbsCsr.deviceNameForOid(attestationValidator.genericDeviceNameOID ?: WardenDefaults.OIDs.DEVICE_NAME)}")
+                    Signer.Ephemeral { ec { } }.getOrThrow().let { signer ->
+                        signer.sign(
+                            TbsCertificate(
+                                serialNumber = Random.nextBytes(32),
+                                publicKey = tbsCsr.publicKey,
+                                signatureAlgorithm = signer.signatureAlgorithm.toX509SignatureAlgorithm().getOrThrow(),
+                                validFrom = Asn1Time(Clock.System.now()),
+                                validUntil = Asn1Time(Clock.System.now() + 10.days),
+                                issuerName = listOf(
+                                    RelativeDistinguishedName(
+                                        AttributeTypeAndValue.CommonName(Asn1String.UTF8("WARDEN Supreme"))
+                                    )
+                                ),
+                                subjectName = tbsCsr.subjectName,
+                            )
+                        ).map { listOf(it) }.getOrThrow()
+                    }
+                },
+            )
+
 
             val server = embeddedServer(Netty, port = 8080) {
                 install(ContentNegotiation) { json() }
@@ -102,56 +180,41 @@ val TestEnv by matrixSuite(matrixConfig { testConfig = TestConfig.testScope(isEn
 
 
                     }
+                    get("$ENDPOINT_CHALLENGE/{scenario}") {
+                        val scenarioName = requireNotNull(call.parameters["scenario"])
+                        val scenario = requireNotNull(authenticationScenarios[scenarioName])
+                        call.respond(
+                            attestationValidator.issueChallenge(
+                                "$ENDPOINT_ATTEST/$scenarioName",
+                                timeZone = TimeZone.currentSystemDefault(),
+                                keyConstraints = WardenDefaults.KeyConstraints.p256Signer,
+                                toBeAttestedAttributes = scenario.expectedAttributes?.let { requestedAttributes },
+                                dataAuth = scenario.authentication,
+                            )
+                        )
+                    }
                     post(PATH_ATTEST) {
                         val src = call.receive<ByteArray>()
                         test("Got Challenge") {}
-
-
-                        val resp =
-                            attestationValidator.verifyAttestation(
-                                Pkcs10CertificationRequest.decodeFromDer(src),
-                                onPreAttestationError = {
-                                    val msg = throwable?.message ?: ""
-                                    println(msg)
-                                    msg
-                                },
-                                onAttestationError = { stmt ->
-                                    println(stmt.serializeCompact())
-                                    stmt.serializeCompact()
-                                }) { csr ->
-                                println("Successfully attested device ${csr.deviceNameForOid(attestationValidator.genericDeviceNameOID ?: WardenDefaults.OIDs.DEVICE_NAME)}")
-                                Signer.Ephemeral {
-                                    ec { }
-                                }.getOrThrow().let { signer ->
-                                    signer.sign(
-                                        TbsCertificate(
-                                            serialNumber = Random.nextBytes(32),
-                                            publicKey = csr.tbsCsr.publicKey,
-                                            signatureAlgorithm = signer.signatureAlgorithm.toX509SignatureAlgorithm()
-                                                .getOrThrow(),
-                                            validFrom = Asn1Time(Clock.System.now()),
-                                            validUntil = Asn1Time(Clock.System.now() + 10.days),
-                                            issuerName = listOf(
-                                                RelativeDistinguishedName(
-                                                    AttributeTypeAndValue.CommonName(
-                                                        Asn1String.UTF8(
-                                                            "WARDEN Supreme"
-                                                        )
-                                                    )
-                                                )
-                                            ),
-                                            subjectName = csr.tbsCsr.subjectName,
-                                        )
-                                    ).map { listOf(it) }.getOrThrow()
-                                }
-                            }
-                        call.respond(resp)
+                        call.respond(
+                            verify(
+                                AttestationProof.Signed(Pkcs10CertificationRequest.decodeFromDer(src)),
+                                AuthenticationScenario(DataAuthentication.Signature, null),
+                            )
+                        )
+                    }
+                    post("$PATH_ATTEST/{scenario}") {
+                        val scenarioName = requireNotNull(call.parameters["scenario"])
+                        val scenario = requireNotNull(authenticationScenarios[scenarioName])
+                        val src = call.receive<ByteArray>()
+                        val proof = AttestationProof.decodeFromDer(src).getOrThrow()
+                        call.respond(verify(proof, scenario))
                     }
 
                 }
             }.start(wait = false)
 
-            val timeout = 5.minutes
+            val timeout = 15.minutes
             println("KTOR server started!")
             println("   Waiting $timeout before auto-shutdown!")
             val before = Clock.System.now()


### PR DESCRIPTION
slight tweaks to make sure
* old clients handle challenges sent by the new verifier (when left with the old config to require signed CSRs)
* new verifiers handle non-caninically encoded CSR attribute lists from old clients