### PR TITLE
Fix/csr hash collision

### DIFF
--- a/supreme/common/src/commonMain/kotlin/SortedSet.kt
+++ b/supreme/common/src/commonMain/kotlin/SortedSet.kt
@@ -1,0 +1,31 @@
+package at.asitplus.attestation.supreme
+
+/** A KMP-compatible immutable set backed by sorted values, never by attacker-controlled hashes. */
+internal class SortedSet<E>(
+    values: Collection<E>,
+    private val comparator: Comparator<E>,
+    private val hash: (E) -> Int = { it.hashCode() },
+) : Set<E> {
+    private val canonicalValues = values.sortedWith(comparator).let { sorted ->
+        sorted.filterIndexed { index, value ->
+            index == 0 || comparator.compare(sorted[index - 1], value) != 0
+        }
+    }
+
+    override val size get() = canonicalValues.size
+    override fun isEmpty() = canonicalValues.isEmpty()
+    override fun iterator() = canonicalValues.iterator()
+    override fun contains(element: E) = canonicalValues.binarySearch { comparator.compare(it, element) } >= 0
+    override fun containsAll(elements: Collection<E>) = elements.all(::contains)
+    override fun equals(other: Any?): Boolean {
+        if (other !is Set<*> || size != other.size) return false
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            containsAll(other as Set<E>)
+        } catch (_: ClassCastException) {
+            false
+        }
+    }
+
+    override fun hashCode() = canonicalValues.fold(0) { result, value -> result + hash(value) }
+}

--- a/supreme/common/src/commonMain/kotlin/SortedSet.kt
+++ b/supreme/common/src/commonMain/kotlin/SortedSet.kt
@@ -1,7 +1,7 @@
 package at.asitplus.attestation.supreme
 
 /** A KMP-compatible immutable set backed by sorted values, never by attacker-controlled hashes. */
-internal class SortedSet<E>(
+class SortedSet<E>(
     values: Collection<E>,
     private val comparator: Comparator<E>,
     private val hash: (E) -> Int = { it.hashCode() },

--- a/supreme/common/src/jvmTest/kotlin/SortedSetTests.kt
+++ b/supreme/common/src/jvmTest/kotlin/SortedSetTests.kt
@@ -1,0 +1,28 @@
+package at.asitplus.attestation.supreme
+
+import at.asitplus.testballoon.matrix.matrixSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.int
+
+val SortedSetTests by matrixSuite {
+    property(
+        "deduplicates colliding values without hash-table insertion",
+        Arb.bind(Arb.int(-1_000, 1_000), Arb.int(-1_000, 1_000), Arb.int(-1_000, 1_000)) { a, b, c ->
+            listOf(CollidingValue(a), CollidingValue(b), CollidingValue(c), CollidingValue(a))
+        },
+        iterations = 256,
+    ) test { values ->
+        val actual = SortedSet(values, compareBy(CollidingValue::value))
+        val expected = values.toHashSet()
+
+        actual.containsAll(expected) shouldBe true
+        expected.containsAll(actual) shouldBe true
+    }
+}
+
+private class CollidingValue(val value: Int) {
+    override fun equals(other: Any?) = other is CollidingValue && value == other.value
+    override fun hashCode() = 0
+}

--- a/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt
@@ -29,6 +29,19 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
 private val extensionRequestOid = ObjectIdentifier("1.2.840.113549.1.9.14")
+private val objectIdentifierComparator = Comparator<ObjectIdentifier> { left, right ->
+    left.bytes.compareUnsigned(right.bytes)
+}
+
+private fun ByteArray.compareUnsigned(other: ByteArray): Int {
+    var index = 0
+    while (index < minOf(size, other.size)) {
+        val result = (this[index].toInt() and 0xff) - (other[index].toInt() and 0xff)
+        if (result != 0) return result
+        index++
+    }
+    return size.compareTo(other.size)
+}
 
 /**
  * Verifies attestation statements and issues certificates on success.
@@ -364,7 +377,7 @@ constructor(
         challenge: AttestationChallenge,
         onPreAttestationError: suspend PreAttestationError.() -> String?,
     ): Failure? {
-        if (attributes.map { it.oid }.toSet().size != attributes.size) {
+        if (SortedSet(attributes.map { it.oid }, objectIdentifierComparator).size != attributes.size) {
             return clientDataValidationFailure(
                 type = Type.CONTENT,
                 reason = PreAttestationError.ClientDataValidation.Reason.DUPLICATE_CSR_ATTRIBUTE_OID,
@@ -390,7 +403,7 @@ constructor(
                     throwable = it,
                 )
             }
-            if (extensions.map { it.oid }.toSet().size != extensions.size) {
+            if (SortedSet(extensions.map { it.oid }, objectIdentifierComparator).size != extensions.size) {
                 return clientDataValidationFailure(
                     type = Type.CONTENT,
                     reason = PreAttestationError.ClientDataValidation.Reason.DUPLICATE_CSR_EXTENSION_OID,


### PR DESCRIPTION
> [!NOTE]
> This was originally privately reported by @mschwarzl, but since it never impacted any release or snapshot, but only the recently pushed changes to `development`, it is a regular, public PR.

**Summary**

`AttestationVerifier` accepts an unbounded number of CSR attributes and checks OID uniqueness by converting attacker-controlled `ObjectIdentifier` values to a hash set. An attacker can generate thousands of distinct, valid OIDs with identical hash codes, forcing superlinear CPU work before attestation authenticity is checked.

**Details**

The signed CSR is attacker-controlled input. In `supreme/verifier/src/jvmMain/kotlin/AttestationVerifier.kt:362-376`, `csrStructureFailure()` executes `attributes.map { it.oid }.toSet()` with no attribute-count or encoded-size limit. This happens during pre-attestation processing. Distinct OIDs can be generated from equal-hash arc pairs: each `.1.0` and `.0.31` pair contributes the same polynomial hash value. Fourteen pairs produce 16,384 distinct OIDs in one collision set.

A caller only needs a normal bearer challenge and a key capable of signing the crafted CSR. No valid Android or iOS attestation is needed to reach the expensive uniqueness check. Concurrent requests consume verifier workers and delay legitimate attestations.

**PoC**

The reproducer generated each OID as follows, attached every OID as a distinct CSR attribute, signed the CSR, and passed it to the real verifier:

```kotlin
fun collidingOid(value: Int, bits: Int): ObjectIdentifier {
    val oid = StringBuilder("1.2")
    repeat(bits) { bit ->
        if (value and (1 shl bit) == 0) oid.append(".1.0")
        else oid.append(".0.31")
    }
    return ObjectIdentifier(oid.toString())
}

val oids = (0 until (1 shl 14)).map { collidingOid(it, 14) }
require(oids.toSet().size == 16_384)
require(oids.map { it.hashCode() }.toSet().size == 1)
```

Executed results against `feature/hashed` at commit `0a23501be629d547015f945aff9c79ddeaafade2`:

```
16,384 attributes, 590,094-byte CSR: approximately 947 ms verifier time
32,768 attributes: approximately 4.29 s verifier time
```

Doubling the collision set increased verifier time by about 4.5x.

**Impact**

An attacker can cause algorithmic-complexity denial of service in applications exposing the Supreme verifier. The work occurs before genuine platform attestation verification and can be repeated with newly issued challenges.

**Remediation**

Reject CSRs exceeding a small fixed attribute count and encoded-size limit before constructing collections. Avoid relying on attacker-controlled hash distribution for uniqueness checks.