### PR TITLE
Release/1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Since Warden Supreme is an evolution of WARDEN and continues to maintain and pub
 dedicated artefacts,
 this changelog also includes the original WARDEN changelog.
 
-## NEXT
+## 1.1.0
 * Remove Deprecations schedules for removal in 1.1
 * Deprecate APIs with rough edges (will be removed in Warden Supreme 1.3)
 * **Rework iOS App Attest assertion validation**
@@ -36,13 +36,17 @@ this changelog also includes the original WARDEN changelog.
     * Add `dataAuthentication` and human-readable `toBeAttestedAttributes` support to `SupremeConfiguration` JSON/YAML.
     * Expand client, verifier, property, and Android-emulator end-to-end coverage for both authentication modes and
       required/optional attribute combinations.
-    * Bump ChallengeVersion to 3, but still transmit 2, of DataAuthentication.Signature is used without any requested to-be-attested attributes
+    * Bump ChallengeVersion to 3, but still transmit 2, of DataAuthentication.Signature is used without any requested to-be-attested attributes  
+      **This keeps compatibility between non-aligned clients and verifiers across Warden Supreme 1.0 and 1.1.**
 * Add Supreme dependency to `supreme-common`
+* Dependency Updates:
+    * Bouncy Castle 1.85
+    * Signum Indispensable 3.25.0
 
 ## 1.0.3
 * Security hardening:
     * Verify Android attestation certificate chains before fully decoding their attacker-controlled attestation extensions.
-    * Use a narrowly scoped, size-limited application-ID extraction for per-application trust-anchor selection.
+    * Use a narrowly scoped, size-limited application-ID extraction for per-application trust-anchor selection ((GHSA-4r28-jj7j-g7v8)[https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-4r28-jj7j-g7v8])
     * Canonicalize Android application package information and signer digests with ordered collections rather than attacker-controlled hash sets.
     * Replace full-cache expiry scans in `InMemoryChallengeCache` with nonce- and expiry-ordered indexes ([GHSA-3chr-q239-rmpp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3chr-q239-rmpp)).
     * Bound payload sizes and recursion depth ([GHSA-qv7m-wr3r-hfg3](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-qv7m-wr3r-hfg3)) ([GHSA-3qj3-8wvm-fmcp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3qj3-8wvm-fmcp))
@@ -60,7 +64,7 @@ this changelog also includes the original WARDEN changelog.
 # 1.0.2
 * Ktor 3.5.1
 * kotlinx.datetime 0.8.0
-* Assert security level from certificate chain (Addresses GHSA-frpv-cj76-xm4r)
+* Assert security level from certificate chain ([GHSA-frpv-cj76-xm4r](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-frpv-cj76-xm4r))
     * **For Strongbox-requiring policies**, the attestation security level is now **derived from the certificate chain** and must match the level advertised in the attestation extension (`keymasterSecurityLevel`). A mismatch now fails verification.
     * **Impact on generated attestation chains (automated testing):** synthetic chains must now be shaped to match the claimed security level. Chains that previously passed (e.g. a three-certificate chain advertising a StrongBox extension) are now rejected — either with a certificate-trust error (wrong chain shape) or an `AttestationValueException` for the security-level mismatch (surfaced as `CONTENT`). Required shapes:
         * **StrongBox** (factory-provisioned): `ROOT → FACTORY_INTERMEDIATE → ATTESTATION → TARGET` (four certificates). The factory intermediate's subject must carry a serialNumber (OID `2.5.4.5`) **and** a title (OID `2.5.4.12`) of exactly `TEE` or `StrongBox`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.plugins.signing.Sign
 
 plugins {
@@ -69,6 +70,13 @@ val publishedProjects = listOf(
     project(":config-hoplite"),
     project(":config-spring"),
 )
+
+publishedProjects.forEach { moduleProject ->
+    moduleProject.tasks.register<Jar>("javadocRedirectJar") {
+        archiveClassifier.set("javadoc")
+        from(rootProject.layout.projectDirectory.dir("docs/javadoc"))
+    }
+}
 
 val releasePublicationsByProject = linkedMapOf(
     ":makoto" to listOf("mavenJava"),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import groovy.json.JsonSlurper
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.plugins.signing.Sign
 
 plugins {
     val kotlinVer = System.getenv("KOTLIN_VERSION_ENV")?.ifBlank { null } ?: libs.versions.kotlin.get()
@@ -117,8 +116,6 @@ tasks.register("loaderMutationTest") {
     )
 }
 
-val signLocalRepoArtefacts = System.getenv("SIGN_LOCAL_REPO_ARTEFACTS")?.ifBlank { "false" } == "true"
-
 val syncSbomDocs by tasks.register("syncSbomDocs") {
     group = "documentation"
     description = "Exports CycloneDX SBOMs for all published Maven publications into the docs tree."
@@ -129,16 +126,21 @@ val syncSbomDocs by tasks.register("syncSbomDocs") {
     val sbomRendererFile = rootProject.layout.projectDirectory.file("docs/tools/render_sbom_pages.py")
     val sortedProjects = publishedProjects.sortedBy { it.name }
 
+    // Depend on the *Normalized* task, not the base one: `cyclonedx<Pub>PublicationBom` only emits `bom.raw.{json,xml}`;
+    // the normalized `bom.json` we parse below (the one carrying the `…?…&type=` purl) is produced by
+    // `…PublicationBomNormalized`. Depending on the base task left `bom.json` absent on clean CI checkouts, so `entries`
+    // came out empty and no module pages were rendered — which then failed the strict mkdocs build.
+    val bomJsonFiles = releasePublicationsByProject.flatMap { (projectPath, publicationNames) ->
+        publicationNames.map { publicationName ->
+            project(projectPath).layout.buildDirectory.file("reports/cyclonedx-publications/$publicationName/bom.json")
+        }
+    }
     dependsOn(releasePublicationsByProject.flatMap { (projectPath, publicationNames) ->
         publicationNames.map { publicationName ->
-            "$projectPath:cyclonedx${publicationName.replaceFirstChar { it.uppercase() }}PublicationBom"
+            "$projectPath:cyclonedx${publicationName.replaceFirstChar { it.uppercase() }}PublicationBomNormalized"
         }
     })
-    if (signLocalRepoArtefacts) {
-        dependsOn(sortedProjects.map { project ->
-            project.tasks.withType(Sign::class.java)
-        })
-    }
+    inputs.files(bomJsonFiles)
     inputs.file(sbomTemplateFile)
     inputs.file(sbomRendererFile)
     outputs.file(sbomIndexFile)
@@ -146,7 +148,6 @@ val syncSbomDocs by tasks.register("syncSbomDocs") {
 
     doLast {
         val jsonSlurper = JsonSlurper()
-        val repoRoot = rootProject.layout.projectDirectory.dir("repo").asFile
         val sbomPublicationsDir = sbomDocsDir.dir("publications").asFile
         val mavenCentralBaseUrl = "https://repo1.maven.org/maven2"
         val entries = sortedProjects.flatMap { moduleProject ->
@@ -154,7 +155,11 @@ val syncSbomDocs by tasks.register("syncSbomDocs") {
             releasePublicationsByProject[moduleProject.path].orEmpty().mapNotNull { publicationName ->
                 val publicationDir = publicationRoot.resolve(publicationName)
                 val bomJsonFile = publicationDir.resolve("bom.json")
-                if (!bomJsonFile.isFile) return@mapNotNull null
+                check(bomJsonFile.isFile) {
+                    "Expected normalized CycloneDX SBOM at $bomJsonFile for ${moduleProject.path} publication " +
+                        "'$publicationName', but it is missing. Ensure " +
+                        "cyclonedx${publicationName.replaceFirstChar { it.uppercase() }}PublicationBomNormalized ran."
+                }
 
                 @Suppress("UNCHECKED_CAST")
                 val bom = jsonSlurper.parse(bomJsonFile) as Map<String, Any?>
@@ -167,41 +172,11 @@ val syncSbomDocs by tasks.register("syncSbomDocs") {
                 val groupId = component["group"]?.toString().orEmpty()
                 val artifactId = component["name"]?.toString().orEmpty()
                 val version = component["version"]?.toString().orEmpty()
-                val artifactDir = repoRoot.resolve(groupId.replace('.', '/')).resolve(artifactId).resolve(version)
-                val packaging = artifactDir
-                    .listFiles()
-                    .orEmpty()
-                    .mapNotNull { artifactFile ->
-                        artifactFile.name
-                            .removePrefix("$artifactId-$version.")
-                            .takeIf {
-                                artifactFile.isFile &&
-                                        artifactFile.name.startsWith("$artifactId-$version.") &&
-                                        it !in setOf(
-                                    "pom",
-                                    "module",
-                                    "json",
-                                    "xml",
-                                    "jar.asc",
-                                    "aar.asc",
-                                    "klib.asc",
-                                    "module.asc",
-                                    "pom.asc",
-                                    "json.asc",
-                                    "xml.asc",
-                                    "javadoc.jar",
-                                    "sources.jar",
-                                    "kotlin-tooling-metadata.json",
-                                    "metadata.jar",
-                                ) &&
-                                        !artifactFile.name.endsWith(".md5") &&
-                                        !artifactFile.name.endsWith(".sha1") &&
-                                        !artifactFile.name.endsWith(".sha256") &&
-                                        !artifactFile.name.endsWith(".sha512")
-                            }
-                    }
-                    .firstOrNull()
-                    ?: ""
+                // Extrapolate the packaging from the CycloneDX purl (`…?…&type=jar|aar|klib`) rather than scanning the
+                // locally published `repo/` tree. We only ever *link* to the SBOMs published on Maven Central, so full
+                // docs can be generated without publishing (and therefore without signing) any artefacts locally.
+                val purl = component["purl"]?.toString().orEmpty()
+                val packaging = Regex("[?&]type=([^&]+)").find(purl)?.groupValues?.get(1).orEmpty()
 
                 val mavenCentralArtifactBase = buildString {
                     append(mavenCentralBaseUrl)
@@ -235,6 +210,11 @@ val syncSbomDocs by tasks.register("syncSbomDocs") {
                     "mavenCentralClassifier" to "cyclonedx",
                 )
             }
+        }
+        check(entries.isNotEmpty()) {
+            "No CycloneDX SBOMs were found for any published publication. The generated docs would reference module " +
+                "pages that are never created, failing the strict mkdocs build. Check that the cyclonedx…" +
+                "PublicationBomNormalized tasks produced reports/cyclonedx-publications/<publication>/bom.json."
         }
         val sbomModulesDir = sbomDocsDir.dir("modules").asFile
         sbomPublicationsDir.deleteRecursively()

--- a/docs/docs/hardening.md
+++ b/docs/docs/hardening.md
@@ -1,0 +1,91 @@
+# Security Policy and Hardening
+
+This page provides an overview of Warden Supreme's official security policy, how we handle reports, and how we have
+hardened Warden Supreme against attacks.
+
+## Security Policy
+
+Please do **not** report security issues **publicly**. Attackers might use such information to exploit
+vulnerabilities before a fix can be developed and deployed.
+
+Instead, please use GitHub's [**private vulnerability reporting**](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability):
+
+![GitHub's "Report a vulnerability" button](https://github.com/user-attachments/assets/ab4a2c05-6948-498b-9a1d-01fe162a0b1e){ style="width: 100%; height: auto;" loading=lazy }
+
+- Navigate to the repository's *Security and quality* section on GitHub.
+- Click *Report a vulnerability*.
+- Follow the private vulnerability reporting flow.
+
+**Please include:**
+
+- A description of the issue.
+- Affected versions, commits, or components.
+- Reproduction steps or a proof of concept, as far as possible.
+- The impact and any suggested mitigation.
+
+**We will:**
+
+- Acknowledge reports promptly.
+- Assess severity and impact.
+- Work on a fix or mitigation.
+- Coordinate disclosure responsibly.
+
+Response and remediation times may vary depending on report complexity, maintainer availability, and release timing.
+
+
+## Hardening
+
+We believe in transparency. Therefore, we document flaws discovered in released versions, what we did to address them,
+and how long it took for fixes to reach a release. Released versions are listed first; advisory records without a
+released patch are accounted for separately below.
+
+- Some discoveries also affected third-party libraries. We reported them upstream and coordinated releases to avoid
+  cross-project exposure.
+- Others affected only Warden Supreme; their remediation timelines were entirely our responsibility.
+
+!!! tip inline end "Primary Advisory Source"
+    [GitHub](https://github.com/a-sit-plus/warden-supreme/security/advisories) is the primary advisory source and may be
+    updated a few hours before this page.
+
+We update this section as new discoveries are made. Always consult the latest published documentation for an up-to-date
+overview.
+
+### Warden Supreme 1.1.0
+
+Released on **2026-08-14**.
+
+| State | Advisory | Short description                                                                                                                               | Reported | Assessed | Resolution |
+|---|---|-------------------------------------------------------------------------------------------------------------------------------------------------|---:|---:|---|
+| Published | [GHSA-6jpm-5g92-cpcg](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-6jpm-5g92-cpcg) | Rejects duplicate CSR attributes and extensions. Strictly defence-in-depth, as Warden Supreme delegates semantic CSR validation to integrators. | TBD | 2026-08-02 | Fix not yet released |
+
+
+### Warden Supreme 1.0.3
+
+Released on **2026-08-12**.
+
+| Advisory | Short description | Reported | Assessed | Patched/released |
+|---|---|---:|---:|---:|
+| [GHSA-4r28-jj7j-g7v8](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-4r28-jj7j-g7v8) | Limits and canonicalises attacker-controlled Android application IDs and signer digests, and verifies certificate chains before fully decoding attestation extensions. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
+| [GHSA-3chr-q239-rmpp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3chr-q239-rmpp) | Replaces full-cache expiry scans with nonce- and expiry-ordered indexes to prevent quadratic CPU denial of service. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
+| [GHSA-qv7m-wr3r-hfg3](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-qv7m-wr3r-hfg3) | Adds payload-size and nesting guards to prevent verifier stack exhaustion during hybrid JSON deserialisation. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
+| [GHSA-3qj3-8wvm-fmcp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3qj3-8wvm-fmcp) | Bounds nested challenge payload deserialisation to prevent a malicious challenge endpoint from crashing clients. | TBD | 2026-08-05 | 2026-08-12 (1.0.3) |
+| [GHSA-744h-w68v-qfpc](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-744h-w68v-qfpc) | Clarifies the verifier's hardware/software OR semantics so operators do not accidentally weaken their attestation policy. | TBD | 2026-08-05 | 2026-08-12 (1.0.3) |
+| [GHSA-rxrw-2p38-wfmr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-rxrw-2p38-wfmr) | Rejects duplicate or conflicting singleton tags in the Supreme `AuthorizationList` parser. | TBD | 2026-08-09 | 2026-08-12 (1.0.3) |
+| [GHSA-2f9g-97q5-f2wr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-2f9g-97q5-f2wr) | Includes the App Attest environment in iOS policy selection, preventing sandbox and production policies from being confused. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
+
+### Warden Supreme 1.0.2
+
+Released on **2026-07-15**.
+
+| Advisory | Short description | Reported | Assessed | Patched/released |
+|---|---|---:|---:|---:|
+| [GHSA-frpv-cj76-xm4r](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-frpv-cj76-xm4r) | Derives the attestation security level from the certificate chain and requires it to match the level claimed by the attestation extension, preventing StrongBox impersonation. | TBD | 2026-07-06 | 2026-07-15 (1.0.2) |
+
+### Warden Supreme 1.0.1
+
+Released on **2026-06-24**. Warden Supreme itself had no published advisory
+for this release; it updated Signum to the version containing the upstream fix below.
+
+| Advisory | Short description | Reported | Assessed | Patched/released |
+|---|---|---:|---:|---:|
+| [Signum GHSA-hch5-9pjg-jqjh](https://github.com/a-sit-plus/signum/security/advisories/GHSA-hch5-9pjg-jqjh) | Updates to Signum 3.24.0, which bounds recursive ASN.1 operations that could otherwise cause denial of service. | TBD | 2026-06-24 | 2026-06-24 (1.0.1) |

--- a/docs/docs/hardening.md
+++ b/docs/docs/hardening.md
@@ -10,7 +10,11 @@ vulnerabilities before a fix can be developed and deployed.
 
 Instead, please use GitHub's [**private vulnerability reporting**](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability):
 
+---
+
 ![GitHub's "Report a vulnerability" button](https://github.com/user-attachments/assets/ab4a2c05-6948-498b-9a1d-01fe162a0b1e){ style="width: 100%; height: auto;" loading=lazy }
+
+---
 
 - Navigate to the repository's *Security and quality* section on GitHub.
 - Click *Report a vulnerability*.
@@ -54,38 +58,38 @@ overview.
 
 Released on **2026-08-14**.
 
-| State | Advisory | Short description                                                                                                                               | Reported | Assessed | Resolution |
-|---|---|-------------------------------------------------------------------------------------------------------------------------------------------------|---:|---:|---|
-| Published | [GHSA-6jpm-5g92-cpcg](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-6jpm-5g92-cpcg) | Rejects duplicate CSR attributes and extensions. Strictly defence-in-depth, as Warden Supreme delegates semantic CSR validation to integrators. | TBD | 2026-08-02 | Fix not yet released |
+| State     | Advisory                                                                                                    | Short description                                                                                                                               |   Reported |   Assessed | Resolution |
+|-----------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-----------:|-----------:|------------|
+| Published | [GHSA-6jpm-5g92-cpcg](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-6jpm-5g92-cpcg) | Rejects duplicate CSR attributes and extensions. Strictly defence-in-depth, as Warden Supreme delegates semantic CSR validation to integrators. | 2026-08-02 | 2026-08-02 | 2026-08-14 |
 
 
 ### Warden Supreme 1.0.3
 
 Released on **2026-08-12**.
 
-| Advisory | Short description | Reported | Assessed | Patched/released |
-|---|---|---:|---:|---:|
-| [GHSA-4r28-jj7j-g7v8](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-4r28-jj7j-g7v8) | Limits and canonicalises attacker-controlled Android application IDs and signer digests, and verifies certificate chains before fully decoding attestation extensions. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
-| [GHSA-3chr-q239-rmpp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3chr-q239-rmpp) | Replaces full-cache expiry scans with nonce- and expiry-ordered indexes to prevent quadratic CPU denial of service. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
-| [GHSA-qv7m-wr3r-hfg3](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-qv7m-wr3r-hfg3) | Adds payload-size and nesting guards to prevent verifier stack exhaustion during hybrid JSON deserialisation. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
-| [GHSA-3qj3-8wvm-fmcp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3qj3-8wvm-fmcp) | Bounds nested challenge payload deserialisation to prevent a malicious challenge endpoint from crashing clients. | TBD | 2026-08-05 | 2026-08-12 (1.0.3) |
-| [GHSA-744h-w68v-qfpc](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-744h-w68v-qfpc) | Clarifies the verifier's hardware/software OR semantics so operators do not accidentally weaken their attestation policy. | TBD | 2026-08-05 | 2026-08-12 (1.0.3) |
-| [GHSA-rxrw-2p38-wfmr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-rxrw-2p38-wfmr) | Rejects duplicate or conflicting singleton tags in the Supreme `AuthorizationList` parser. | TBD | 2026-08-09 | 2026-08-12 (1.0.3) |
-| [GHSA-2f9g-97q5-f2wr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-2f9g-97q5-f2wr) | Includes the App Attest environment in iOS policy selection, preventing sandbox and production policies from being confused. | TBD | 2026-08-07 | 2026-08-12 (1.0.3) |
+| Advisory                                                                                                    | Short description                                                                                                                                                      |   Reported |   Assessed |   Patched/released |
+|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------:|-----------:|-------------------:|
+| [GHSA-4r28-jj7j-g7v8](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-4r28-jj7j-g7v8) | Limits and canonicalises attacker-controlled Android application IDs and signer digests, and verifies certificate chains before fully decoding attestation extensions. | 2026-08-05 | 2026-08-07 | 2026-08-12 (1.0.3) |
+| [GHSA-3chr-q239-rmpp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3chr-q239-rmpp) | Replaces full-cache expiry scans with nonce- and expiry-ordered indexes to prevent quadratic CPU denial of service.                                                    | 2026-08-05 | 2026-08-07 | 2026-08-12 (1.0.3) |
+| [GHSA-qv7m-wr3r-hfg3](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-qv7m-wr3r-hfg3) | Adds payload-size and nesting guards to prevent verifier stack exhaustion during hybrid JSON deserialisation.                                                          | 2026-08-05 | 2026-08-07 | 2026-08-12 (1.0.3) |
+| [GHSA-3qj3-8wvm-fmcp](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-3qj3-8wvm-fmcp) | Bounds nested challenge payload deserialisation to prevent a malicious challenge endpoint from crashing clients.                                                       | 2026-08-05 | 2026-08-05 | 2026-08-12 (1.0.3) |
+| [GHSA-744h-w68v-qfpc](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-744h-w68v-qfpc) | Clarifies the verifier's hardware/software OR semantics so operators do not accidentally weaken their attestation policy.                                              | 2026-08-05 | 2026-08-05 | 2026-08-12 (1.0.3) |
+| [GHSA-rxrw-2p38-wfmr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-rxrw-2p38-wfmr) | Safely returns repeated singleton tags when their values agree and reports conflicting values as failures.                                                             | 2026-08-05 | 2026-08-09 | 2026-08-12 (1.0.3) |
+| [GHSA-2f9g-97q5-f2wr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-2f9g-97q5-f2wr) | Includes the App Attest environment in iOS policy selection, preventing sandbox and production policies from being confused.                                           | 2026-08-05 | 2026-08-07 | 2026-08-12 (1.0.3) |
 
 ### Warden Supreme 1.0.2
 
 Released on **2026-07-15**.
 
-| Advisory | Short description | Reported | Assessed | Patched/released |
-|---|---|---:|---:|---:|
-| [GHSA-frpv-cj76-xm4r](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-frpv-cj76-xm4r) | Derives the attestation security level from the certificate chain and requires it to match the level claimed by the attestation extension, preventing StrongBox impersonation. | TBD | 2026-07-06 | 2026-07-15 (1.0.2) |
+| Advisory                                                                                                    | Short description                                                                                                                                                              |   Reported |   Assessed |   Patched/released |
+|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------:|-----------:|-------------------:|
+| [GHSA-frpv-cj76-xm4r](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-frpv-cj76-xm4r) | Derives the attestation security level from the certificate chain and requires it to match the level claimed by the attestation extension, preventing StrongBox impersonation. | 2026-07-06 | 2026-07-06 | 2026-07-15 (1.0.2) |
 
 ### Warden Supreme 1.0.1
 
 Released on **2026-06-24**. Warden Supreme itself had no published advisory
 for this release; it updated Signum to the version containing the upstream fix below.
 
-| Advisory | Short description | Reported | Assessed | Patched/released |
-|---|---|---:|---:|---:|
-| [Signum GHSA-hch5-9pjg-jqjh](https://github.com/a-sit-plus/signum/security/advisories/GHSA-hch5-9pjg-jqjh) | Updates to Signum 3.24.0, which bounds recursive ASN.1 operations that could otherwise cause denial of service. | TBD | 2026-06-24 | 2026-06-24 (1.0.1) |
+| Advisory                                                                                                   | Short description                                                                                               |   Reported |   Assessed |   Patched/released |
+|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------:|-----------:|-------------------:|
+| [Signum GHSA-hch5-9pjg-jqjh](https://github.com/a-sit-plus/signum/security/advisories/GHSA-hch5-9pjg-jqjh) | Updates to Signum 3.24.0, which bounds recursive ASN.1 operations that could otherwise cause denial of service. | 2026-06-22 | 2026-06-24 | 2026-06-24 (1.0.1) |

--- a/docs/docs/integration/config.md
+++ b/docs/docs/integration/config.md
@@ -57,7 +57,7 @@ while reflection-based approaches that bypass primary constructors can also bypa
     Loading like this accepts canonical camelCase, snake_case, UPPER_SNAKE_CASE, and kebap-case property names.
     
     ```kotlin
-    --8<-- "Readme-Config-Hoplite.kt:15:25"
+    --8<-- "Readme-Config-Hoplite.kt:hoplite-config-loader"
     ```
     
     **The decoder is required because Warden Supreme relies on kotlinx.serialization to sanitise, normalise, and parse

--- a/docs/docs/integration/errorhandling.md
+++ b/docs/docs/integration/errorhandling.md
@@ -53,7 +53,7 @@ Note that the `onAttestationError` callback is side-effect-free except that it a
 to customise the error message/error code conveyed to the client.
 
 ```kotlin
---8<-- "Readme-Backend-errorhandling.kt:15:60"
+--8<-- "Readme-Backend-errorhandling.kt:attestation-error-handling"
 ```
 
 1. Refer to [Debugging](debugging.md)
@@ -104,7 +104,7 @@ Note that the `onPreAttestationError` callback is side-effect-free except that i
 to customise the error message/error code conveyed to the client.
 
 ```kotlin
---8<-- "Readme-Backend-preerrorhandling.kt:16:38"
+--8<-- "Readme-Backend-preerrorhandling.kt:pre-attestation-error-handling"
 ```
 
 1. The attestation statement could not be extracted from the received transport. New code receives

--- a/docs/docs/integration/migration.md
+++ b/docs/docs/integration/migration.md
@@ -71,8 +71,11 @@ This section focuses on upgrades that keep using `Makoto` / `Roboto` directly, w
 
 ### Results and Exceptions
 
-!!! tip "Try the custom parser"
-    To enable the custom Android attestation extension parser, set `supremeParser = true` in your configuration and run your usual `Roboto`/`Makoto` verification flow.
+!!! tip "Enable the Supreme parser"
+    Set `supremeParser = true` in your configuration and run your usual `Roboto`/`Makoto` verification flow. Enabling
+    the Supreme parser is recommended, but it remains disabled by default for compatibility and is planned to become the
+    default in a future release. It also handles the repeated `AuthorizationList` tags emitted by some Android 16 devices;
+    see [Duplicate AuthorizationList Tags on Android 16](../technical/quirks.md#duplicate-authorizationlist-tags-on-android-16).
 
 - `AttestationResult` gains a `Verified` marker; NOOP results are distinct.
 - `AttestationResult.Error` always carries a `cause`.

--- a/docs/docs/integration/raw.md
+++ b/docs/docs/integration/raw.md
@@ -135,7 +135,7 @@ Counter semantics are based on the value **before** creating the assertion:
 
 !!! example "Reference implementation (JSON + ASN.1/DER persistence and assertion validation)"
     ```kotlin
-    --8<-- "Readme-Raw-ios-assertion.kt:35:60"
+    --8<-- "Readme-Raw-ios-assertion.kt:ios-assertion-verification"
     ```
 
     1. Registers the incoming App Attest payload and verifies it against the registration challenge.

--- a/docs/docs/integration/supreme.md
+++ b/docs/docs/integration/supreme.md
@@ -132,7 +132,7 @@ Since Android and iOS attestation require different configuration parameters, di
 The following snippet shows an MWE that also accounts for five minutes of clock drift:
 
 ```kotlin
---8<-- "Readme-Config-min.kt:8"
+--8<-- "Readme-Config-min.kt:minimal-makoto-config"
 ```
 
 1. At least package identifier and a single signer digest need to be configured for an Android application to be attested.
@@ -166,7 +166,7 @@ property; the expandable example below shows them together.
     **Be sure to check the annotations!**
     
     ```kotlin
-    --8<-- "Readme-Config.kt:15"
+    --8<-- "Readme-Config.kt:makoto-config"
     ```
     
     1. The basic application for the masses
@@ -237,7 +237,7 @@ boot key hashes, use GrapheneOS's
 [`attestation.json.sig`](https://grapheneos.org/attestation.json.sig).
 
 ```kotlin
---8<-- "Readme-Config-Graphene.kt:15"
+--8<-- "Readme-Config-Graphene.kt:grapheneos-config"
 ```
 
 1. Order is irrelevant, and Warden Supreme makes this explicit by forcing a `Set` of verified boot key hashes
@@ -310,7 +310,7 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
     the deprecated `ChallengeValidator` supports signed CSRs only.
 
 ```kotlin
---8<-- "Readme-Verifier-min.kt:3"
+--8<-- "Readme-Verifier-min.kt:minimal-verifier"
 ```
 
 1. This minimal setup covers most deployments. Defaults include instructions (`KeyConstraints`) for the client to create
@@ -318,7 +318,7 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
 
 ??? example "Comprehensive list of Verifier options"
     ```kotlin
-    --8<-- "Readme-Verifier.kt:30"
+    --8<-- "Readme-Verifier.kt:verifier-config"
     ```
     
     1. We want Warden Supreme to convey the attestation statement payload inside the TBS CSR using a custom OID.
@@ -342,7 +342,7 @@ As such, an `AttestationVerifier` can also be created by passing a `SupremeConfi
 attestation policies, as well as object identifiers, key constraints, authentication mode, and requested attributes:
 
 ```kotlin
---8<-- "Readme-Verifier-config-supreme.kt:15"
+--8<-- "Readme-Verifier-config-supreme.kt:verifier-from-supreme-config"
 ```
 
 1. Default, secure nonce generator.
@@ -359,7 +359,7 @@ server-controlled context sent to the client; it is not client evidence to valid
 Use `additionalVerifications` for such checks:
 
 ```kotlin
---8<-- "Readme-Backend-additional-verifications.kt:17:33"
+--8<-- "Readme-Backend-additional-verifications.kt:additional-verifications"
 ```
 
 1. This is the `AttestationProof` received from the client: a signed CSR or hash-authenticated TBS CSR.
@@ -393,7 +393,7 @@ This example assumes Ktor. Since this is an example environment, TLS is omitted 
     defaults to 1MB.
 
 ```kotlin
---8<-- "Readme-Backend.kt:60"
+--8<-- "Readme-Backend.kt:backend-server"
 ```
 
 1. We're using JSON to transmit the challenge and the final response.
@@ -447,7 +447,7 @@ specifies key constraints:
     endpoint must be treated as a compromise of the attestation flow.
 
 ```kotlin
---8<-- "Readme-client-min.kt:19:40"
+--8<-- "Readme-client-min.kt:minimal-client-flow"
 ```
 
 1. Create an `AttestationClient` from a [Ktor](https://ktor.io/) client.
@@ -473,7 +473,7 @@ The `AttestationClient` doesn't even come with any configuration options.
     If you need more control, you can also manually perform individual steps, as shown below
     
     ```kotlin
-    --8<-- "Readme-client-step-by-step.kt:15:45"
+    --8<-- "Readme-client-step-by-step.kt:step-by-step-client-flow"
     ```
     
     1. Create an `AttestationClient` from a [Ktor](https://ktor.io/) client.
@@ -488,7 +488,7 @@ The `AttestationClient` doesn't even come with any configuration options.
     creating a proof with different semantics:
 
     ```kotlin
-    --8<-- "Readme-client-manual-lowlevel.kt:31:82"
+    --8<-- "Readme-client-manual-lowlevel.kt:manual-client-flow"
     ```
     
     1. Create an `AttestationClient` from a [Ktor](https://ktor.io/) client.
@@ -525,7 +525,7 @@ The back-end still needs enough information to analyse failures. The Supreme att
 four side-effect-free callbacks for challenge validation, attestation errors, and successful verification:
 
 ```kotlin
---8<-- "Readme-Backend-callbacks.kt:18:56"
+--8<-- "Readme-Backend-callbacks.kt:verifier-callbacks"
 ```
 
 1. This is the `AttestationProof` from the client, as in the minimal example.

--- a/docs/docs/integration/supreme.md
+++ b/docs/docs/integration/supreme.md
@@ -1,7 +1,7 @@
 # Warden Supreme Integration
 [![A-SIT Plus Official](https://img.shields.io/badge/A--SIT_Plus-official-005b79?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNDMuNzYyODYgMTg0LjgxOTk5Ij48ZGVmcz48Y2xpcFBhdGggaWQ9ImEiIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cGF0aCBkPSJNMCA1OTUuMjhoODQxLjg5VjBIMFoiLz48L2NsaXBQYXRoPjwvZGVmcz48ZyBjbGlwLXBhdGg9InVybCgjYSkiIHRyYW5zZm9ybT0ibWF0cml4KDEuMzMzMzMzMyAwIDAgLTEuMzMzMzMzMyAtNDgyLjI1IDUxNy41MykiPjxwYXRoIGZpbGw9IiMwMDViNzkiIGQ9Ik00MTUuNjcgMjQ5LjUzYy03LjE1LjA4LTEzLjk0IDEtMjAuMTcgMi43NWE1Mi4zMyA1Mi4zMyAwIDAgMC0xNy40OCA4LjQ2IDQwLjQzIDQwLjQzIDAgMCAwLTExLjk2IDE0LjU2Yy0yLjY4IDUuNDEtNC4xNCAxMS44NC00LjM1IDE5LjA5bC0uMDIgNi4xMnYyLjE3YS43MS43MSAwIDAgMCAuNy43M2gxNi41MmMuMzkgMCAuNy0uMzIuNzEtLjdsLjAxLTIuMmMwLTIuNi4wMi01LjgyLjAzLTYuMDcuMi00LjYgMS4yNC04LjY2IDMuMDgtMTIuMDZhMjguNTIgMjguNTIgMCAwIDEgOC4yMy05LjU4IDM1LjI1IDM1LjI1IDAgMCAxIDExLjk2LTUuNTggNTUuMzggNTUuMzggMCAwIDEgMTIuNTgtMS43NmM0LjMyLjEgOC42LjcgMTIuNzQgMS44YTM1LjA3IDM1LjA3IDAgMCAxIDExLjk2IDUuNTcgMjguNTQgMjguNTQgMCAwIDEgOC4yNCA5LjU3YzEuOTYgMy42NCAzIDguMDIgMy4xMiAxMy4wMnYyNC4wOUgzNjIuNGEuNy43IDAgMCAwLS43MS43VjMzNWMwIDguNDMuMDEgOC4wNS4wMSA4LjE0LjIgNy4zIDEuNjcgMTMuNzcgNC4zNiAxOS4yMmE0MC40MyA0MC40MyAwIDAgMCAxMS45NiAxNC41N2M1IDMuNzYgMTAuODcgNi42MSAxNy40OCA4LjQ2YTc3LjUgNzcuNSAwIDAgMCAyMC4wMiAyLjc3YzcuMTUtLjA3IDEzLjk0LTEgMjAuMTctMi43NGE1Mi4zIDUyLjMgMCAwIDAgMTcuNDgtOC40NiA0MC40IDQwLjQgMCAwIDAgMTEuOTUtMTQuNTdjMS42Mi0zLjI2IDMuNzctMTAuMDQgMy43Ny0xNC42OCAwLS4zOC0uMTctLjc0LS41NC0uODJsLTE2Ljg5LS40Yy0uMi0uMDQtLjM0LjM0LS4zNC41NCAwIC4yNy0uMDMuNC0uMDYuNi0uNSAyLjgyLTEuMzggNS40LTIuNjEgNy42OWEyOC41MyAyOC41MyAwIDAgMS04LjI0IDkuNTggMzUuMDEgMzUuMDEgMCAwIDEtMTEuOTYgNS41NyA1NS4yNSA1NS4yNSAwIDAgMS0xMi41NyAxLjc3Yy00LjMyLS4xLTguNjEtLjcxLTEyLjc1LTEuOGEzNS4wNSAzNS4wNSAwIDAgMS0xMS45Ni01LjU3IDI4LjUyIDI4LjUyIDAgMCAxLTguMjMtOS41OGMtMS44Ni0zLjQ0LTIuOS03LjU1LTMuMDktMTIuMmwtLjAxLTcuNDdoODkuMTZhLjcuNyAwIDAgMCAuNy0uNzJ2LTM5LjVjLS4xLTcuNjUtMS41OC0xNC40LTQuMzgtMjAuMDZhNDAuNCA0MC40IDAgMCAwLTExLjk1LTE0LjU2IDUyLjM3IDUyLjM3IDAgMCAwLTE3LjQ4LTguNDcgNzcuNTYgNzcuNTYgMCAwIDAtMjAuMDEtMi43N1oiLz48cGF0aCBmaWxsPSIjY2U0OTJlIiBkPSJNNDE5LjM4IDI4MC42M2gtNy41N2EuNy43IDAgMCAwLS43MS43MXYxNS40MmE4LjE3IDguMTcgMCAwIDAtMy43OCA2LjkgOC4yOCA4LjI4IDAgMCAwIDE2LjU0IDAgOC4yOSA4LjI5IDAgMCAwLTMuNzYtNi45di0xNS40MmEuNy43IDAgMCAwLS43Mi0uNzEiLz48L2c%2BPC9zdmc%2B&logoColor=white&labelColor=white)](https://a-sit-plus.github.io)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-brightgreen.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Kotlin](https://img.shields.io/badge/kotlin-2.4.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.4.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 ![Java](https://img.shields.io/badge/java-17-blue.svg?logo=OPENJDK)
 [![Maven Central](https://img.shields.io/maven-central/v/at.asitplus.warden/supreme-common)](https://mvnrepository.com/artifact/at.asitplus.warden/)
 
@@ -317,12 +317,52 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
    a hardware-backed P-256 key.
 
 ??? example "Comprehensive list of Verifier options"
+    Warden Supreme 1.1 transitions towards **configuration-based setup** and, as part of this, **deprecates the purely
+    programmatic approach** of instantiating an `AttestationVerifier`. The recommended way is therefore to assemble a
+    `SupremeConfiguration` — which bundles the iOS and Android attestation policies together with object identifiers, key
+    constraints, authentication mode, and requested attributes — and hand it to the verifier. This same configuration can
+    also be externalised entirely (see [Externalising Configuration](config.md)).
+    The deprecated, purely programmatic variant is still listed [further below](#migration-reference-deprecated-programmatic-setup)
+    as a migration reference.
+
+    ```kotlin
+    --8<-- "Readme-Verifier-config.kt:verifier-config-supreme"
+    ```
+
+    1. Android and iOS attestation policies. Here they are lifted from the `Makoto` instance configured above, but you can
+       equally construct the `AndroidAttestationConfiguration` and `IosAttestationConfiguration` directly or load them from
+       externalised configuration.
+    2. We want Warden Supreme to convey the attestation statement payload inside the TBS CSR using a custom OID.
+    3. We don't care about device names in this example and don't require it from the client.
+    4. We explicitly specify the key we want to have created on the client.  
+       The values shown here correspond to the defaults, as this is supported by Android and iOS.
+    5. We require user authentication to use the private key:
+        * Protected by biometric auth
+        * Usable for 30 seconds without reauthentication
+        * Enrolling new biometric factors will invalidate the key
+    6. Request two application-provided values under one dedicated attribute OID. `accountId` is required; `riskScore`
+       may be omitted as `null`. Order and type are part of the schema.
+    7. Authenticate the TBS CSR data by hashing it with SHA-256 and feeding the digest into platform attestation. Set
+       `DataAuthentication.Signature` (the default) when proof of possession is required.
+    8. A custom nonce generator passed to the verifier. The nonce generator and challenge validator are not part of the
+       `SupremeConfiguration`, since they are runtime services rather than policy.
+    9. We want extra long nonces (default: 64 bytes; max: 128 bytes).
+    10. Checking and invalidating challenges is handled by a Redis-backed `AttestationChallengeValidator` (not shown here;
+        roll your own). This is the recommended approach when multiple verifier instances issue challenges. Omit this
+        trailing lambda to use the default bounded in-memory challenge validator.
+
+    #### Migration reference: deprecated programmatic setup
+
+    Before configuration-based setup, the verifier was assembled by passing every parameter programmatically to the
+    `AttestationVerifier` constructor. This still works, but is deprecated as of Warden Supreme 1.1 and only shown here to
+    ease migration of existing integrations. Warden Supreme 1.3 will stop supporting it altogether.
+
     ```kotlin
     --8<-- "Readme-Verifier.kt:verifier-config"
     ```
     
     1. We want Warden Supreme to convey the attestation statement payload inside the TBS CSR using a custom OID.
-    2. We don't care about device names in this example.
+    2. We don't care about device names in this example and don't require it from the client.
     3. We explicitly specify the key we want to have created on the client.  
        The values shown here correspond to the defaults, as this is supported by Android and iOS.
     4. We require user authentication to use the private key:
@@ -335,11 +375,9 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
        may be omitted as `null`. Order and type are part of the schema.
     8. Authenticate the TBS CSR data by hashing it with SHA-256 and feeding the digest into platform attestation. Set
        `DataAuthentication.Signature` (the default) when proof of possession is required.
-    
 
-Instead of passing parameters programmatically, it is also possible to externalise configuration (see [Externalising Configuration](config.md)).
-As such, an `AttestationVerifier` can also be created by passing a `SupremeConfiguration` which contains iOS and Android
-attestation policies, as well as object identifiers, key constraints, authentication mode, and requested attributes:
+The minimal config-based counterpart to the [minimal `Makoto`-based verifier](#attestation-verifier-setup) above simply
+hands a `SupremeConfiguration` to the verifier and relies on the defaults for everything else:
 
 ```kotlin
 --8<-- "Readme-Verifier-config-supreme.kt:verifier-from-supreme-config"

--- a/docs/docs/sbom.md
+++ b/docs/docs/sbom.md
@@ -6,6 +6,12 @@ Each SBOM describes one published Maven artifact, not just one Gradle project. F
 means there is usually one SBOM for the root `kotlinMultiplatform` publication and one SBOM for each concrete target
 publication such as `jvm`, `android`, `iosArm64`, or `iosSimulatorArm64`.
 
+!!! abstract "Machine-Readable Index"
+    A lightweight JSON index of every module/publication pair — with absolute Maven Central URLs for the JSON, XML, and
+    detached `.asc` signature files — is available at
+    [`sbom/index.json`]({{ config.site_url }}/sbom/index.json). See [Documentation Index](#documentation-index) below for
+    details.
+
 ## Formats
 
 - CycloneDX JSON

--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -70,6 +70,10 @@
     font-size: .8rem;
 }
 
+.md-typeset hr {
+    border-color: var(--md-typeset-table-color);
+}
+
 .md-typeset code {
     font-size: 100%;
     font-feature-settings: "kern", "liga";

--- a/docs/docs/technical/quirks.md
+++ b/docs/docs/technical/quirks.md
@@ -146,6 +146,22 @@ sourced from true randomness is recommended anyway (see [Clock Drifts and Tempor
 Some vendors even fail properly encoding DER BOOLEANs. Warden Supreme is lenient about this, but if you are using a strict
 DER decoder, this might trip it.
 
+#### Duplicate `AuthorizationList` Tags on Android 16
+Some Android 16 devices emit non-compliant attestation `AuthorizationList` structures containing multiple entries with
+the same tag. The tried-and-true legacy Google parser, which Warden Supreme currently uses by default, rejects these structures and therefore
+cannot verify affected devices.
+
+Warden Supreme's own _supreme_ parser handles repeated tags without silently choosing one value:
+
+- If every entry with the same tag has the same value, the parser reports that value.
+- If the entries disagree, reading that property returns an error instead of trusting an arbitrary entry.
+
+This behaviour prevents conflicting security-relevant values from overriding one another, as described in
+[GHSA-rxrw-2p38-wfmr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-rxrw-2p38-wfmr), and
+was fixed in Warden Supreme 1.0.3. The Supreme parser is planned to become the default in a future release and can
+already be enabled by setting `supremeParser = true` in the Android attestation configuration (which is generally recommended,
+but not the default for compatibility reasons).
+
 #### Patch Level Misencoding
 Date encoding should be unremarkable. Production certificates prove otherwise.
 

--- a/docs/docs/technical/quirks.md
+++ b/docs/docs/technical/quirks.md
@@ -147,20 +147,20 @@ Some vendors even fail properly encoding DER BOOLEANs. Warden Supreme is lenient
 DER decoder, this might trip it.
 
 #### Duplicate `AuthorizationList` Tags on Android 16
-Some Android 16 devices emit non-compliant attestation `AuthorizationList` structures containing multiple entries with
-the same tag. The tried-and-true legacy Google parser, which Warden Supreme currently uses by default, rejects these structures and therefore
-cannot verify affected devices.
+Some Android 16 devices emit non-compliant attestation `AuthorizationList` structures containing multiple singleton
+entries with the same tag. The tried-and-true legacy Google parser, which Warden Supreme currently uses by default,
+rejects repeated singleton tags and therefore cannot verify affected devices.
 
-Warden Supreme's own _supreme_ parser handles repeated tags without silently choosing one value:
+Warden Supreme's own _Supreme parser_ handles repeated tags without silently choosing one value:
 
-- If every entry with the same tag has the same value, the parser reports that value.
+- If every entry with the same singleton tag has the same value, the parser reports that value.
 - If the entries disagree, reading that property returns an error instead of trusting an arbitrary entry.
 
 This behaviour prevents conflicting security-relevant values from overriding one another, as described in
 [GHSA-rxrw-2p38-wfmr](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-rxrw-2p38-wfmr), and
 was fixed in Warden Supreme 1.0.3. The Supreme parser is planned to become the default in a future release and can
-already be enabled by setting `supremeParser = true` in the Android attestation configuration (which is generally recommended,
-but not the default for compatibility reasons).
+already be enabled by setting `supremeParser = true` in the Android attestation configuration. Enabling it is generally
+recommended; it remains disabled by default for compatibility.
 
 #### Patch Level Misencoding
 Date encoding should be unremarkable. Production certificates prove otherwise.

--- a/docs/javadoc/README.txt
+++ b/docs/javadoc/README.txt
@@ -1,0 +1,1 @@
+Documentation: https://a-sit-plus.github.io/warden-supreme/

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -168,4 +168,5 @@ nav:
         - Config Spring: sbom/modules/config-spring.md
     - Glossary: glossary.md
     - API Docs: dokka/index.html
+    - Security Policy and Hardening: hardening.md
     - 💎 Services: services.md

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx8G
 
-artifactVersion=1.0.3
+artifactVersion=1.1.0
 groupId=at.asitplus.warden
 
 jdk.version=17

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.4.10"
 
 guava = "33.5.0-jre"
 autovalue = "1.11.0"
-signum = "3.24.0"
+signum = "3.25.0"
 supreme = "0.15.0"
 agp = "9.1.1"
 cbor = "0.9"
@@ -20,7 +20,7 @@ androidx = "1.9.1"
 coroutines = "1.10.2"
 hoplite = "2.9.0"
 spring-boot = "4.0.0"
-
+bouncycastle = "1.85"
 #keep it nice and lenient
 semver = "1.2.0"
 serialization ="1.11.0"

--- a/serverside/makoto/build.gradle.kts
+++ b/serverside/makoto/build.gradle.kts
@@ -60,9 +60,10 @@ dependencies {
 }
 
 
-val javadocJar = setupDokka(
+setupDokka(
     baseUrl = "https://github.com/a-sit-plus/warden-supreme/tree/main/serverside",
 )
+val javadocRedirectJar = tasks.named<Jar>("javadocRedirectJar")
 
 val sourcesJar by tasks.registering(Jar::class) {
     archiveClassifier.set("sources")
@@ -75,7 +76,7 @@ publishing {
         register("mavenJava", MavenPublication::class) {
             from(components["java"])
             if (this.name != "relocation") {
-                artifact(javadocJar.get())
+                artifact(javadocRedirectJar)
                 artifact(sourcesJar.get())
             }
             pom {

--- a/serverside/roboto/build.gradle.kts
+++ b/serverside/roboto/build.gradle.kts
@@ -187,9 +187,10 @@ tasks.test {
     useJUnitPlatform()
 }
 
-val javadocJar = setupDokka(
+setupDokka(
     baseUrl = "https://github.com/a-sit-plus/warden-supreme/tree/main/serverside",
 )
+val javadocRedirectJar = tasks.named<Jar>("javadocRedirectJar")
 
 val sourcesJar by tasks.registering(Jar::class) {
     archiveClassifier.set("sources")
@@ -202,7 +203,7 @@ publishing {
         register("mavenJava", MavenPublication::class) {
             from(components["java"])
             if (this.name != "relocation") {
-                artifact(javadocJar.get())
+                artifact(javadocRedirectJar)
                 artifact(sourcesJar.get())
             }
             pom {

--- a/serverside/roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
+++ b/serverside/roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
@@ -442,7 +442,11 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
     val enforceFactoryProvisionedChainValidity: Boolean = true,
 
     /**
-     * Flag to try out the new supreme parser
+     * Selects Warden Supreme's Android attestation parser instead of the legacy Google parser.
+     *
+     * The Supreme parser accepts repeated `AuthorizationList` tags when their values agree and reports conflicting
+     * values as failures instead of selecting an arbitrary occurrence. Enabling it is recommended, but this defaults to
+     * `false` for compatibility. The Supreme parser is planned to become the default in a future release.
      */
     val supremeParser: Boolean = false,
 
@@ -565,9 +569,7 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
 
         enforceFactoryProvisionedChainValidity: Boolean = true,
 
-        /**
-         * Flag to try out the new supreme parser
-         */
+        /** @see AndroidAttestationConfiguration.supremeParser */
         supremeParser: Boolean = false,
 
         /**
@@ -714,9 +716,7 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
 
         enforceFactoryProvisionedChainValidity: Boolean = true,
 
-        /**
-         * Flag to try out the new supreme parser
-         */
+        /** @see AndroidAttestationConfiguration.supremeParser */
         supremeParser: Boolean = false,
 
         /**
@@ -1186,9 +1186,7 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
         fun enforceFactoryProvisionedChainValidity(enforce: Boolean) =
             apply { enforceFactoryProvisionedChainValidity = enforce }
 
-        /**
-         * Flag to try out the new supreme parser
-         */
+        /** @see AndroidAttestationConfiguration.supremeParser */
         fun supremeParser(supremeParser: Boolean) = apply { this.supremeParser = supremeParser }
 
 

--- a/supreme/client/build.gradle.kts
+++ b/supreme/client/build.gradle.kts
@@ -147,14 +147,15 @@ tasks.matching { it.name.contains("installAndroidDeviceTest") }.configureEach {
     mustRunAfter(resignTestApk)
 }
 
-val javadocJar = setupDokka(
+setupDokka(
     baseUrl = "https://github.com/a-sit-plus/warden-supreme/tree/main/supreme",
 )
+val javadocRedirectJar = tasks.named<Jar>("javadocRedirectJar")
 
 publishing {
     publications {
         withType<MavenPublication> {
-            artifact(javadocJar)
+            artifact(javadocRedirectJar)
             pom {
                 name.set("Warden Supreme Client")
                 description.set("Attestation mobile client; part of the WARDEN Supreme integrated key attestation suite")

--- a/supreme/client/src/commonTest/kotlin/examples/Readme-client-manual-lowlevel.kt
+++ b/supreme/client/src/commonTest/kotlin/examples/Readme-client-manual-lowlevel.kt
@@ -28,6 +28,7 @@ suspend fun lowlevel() {
 
 
 
+    // --8<-- [start:manual-client-flow]
  /*(1)!*/val client = AttestationClient(ktorClient)
  /*(2)!*/val serverChallenge = client.getChallenge(Url(ENDPOINT_CHALLENGE)).getOrThrow()
     require(serverChallenge.dataAuth == DataAuthentication.Signature) {
@@ -80,6 +81,7 @@ suspend fun lowlevel() {
             }
         }
     }
+    // --8<-- [end:manual-client-flow]
 
 
 

--- a/supreme/client/src/commonTest/kotlin/examples/Readme-client-min.kt
+++ b/supreme/client/src/commonTest/kotlin/examples/Readme-client-min.kt
@@ -16,6 +16,7 @@ suspend fun main() {
 
 
 
+    // --8<-- [start:minimal-client-flow]
  /*(1)!*/val client = AttestationClient(ktorClient)
 
  /*(2)!*/when (val result = client.performAttestationFlow(ALIAS, Url(ENDPOINT_CHALLENGE)) { requested ->
@@ -38,6 +39,7 @@ suspend fun main() {
             }
         }
     }
+    // --8<-- [end:minimal-client-flow]
 
 
 

--- a/supreme/client/src/commonTest/kotlin/examples/Readme-client-step-by-step.kt
+++ b/supreme/client/src/commonTest/kotlin/examples/Readme-client-step-by-step.kt
@@ -12,6 +12,7 @@ import io.ktor.http.*
 suspend fun stepbystep() {
 
 
+    // --8<-- [start:step-by-step-client-flow]
  /*(1)!*/val client = AttestationClient(ktorClient)
  /*(2)!*/val challenge = client.getChallenge(Url(ENDPOINT_CHALLENGE)).getOrThrow()
 
@@ -43,6 +44,7 @@ suspend fun stepbystep() {
             }
         }
     }
+    // --8<-- [end:step-by-step-client-flow]
 
 
 

--- a/supreme/common/build.gradle.kts
+++ b/supreme/common/build.gradle.kts
@@ -72,9 +72,10 @@ kotlin {
     }
 }
 
-val javadocJar = setupDokka(
+setupDokka(
     baseUrl = "https://github.com/a-sit-plus/warden-supreme/tree/main/supreme",
 )
+val javadocRedirectJar = tasks.named<Jar>("javadocRedirectJar")
 
 dokka.dokkaSourceSets.named("commonMain") {
     // Dokka 2.2.0 crashes while translating context-parameter property getters: Kotlin/dokka#4519.
@@ -86,7 +87,7 @@ dokka.dokkaSourceSets.named("commonMain") {
 publishing {
     publications {
         withType<MavenPublication> {
-            artifact(javadocJar)
+            artifact(javadocRedirectJar)
             pom {
                 name.set("Warden Supreme Commons")
                 description.set("Attestation datatypes and utilities; part of the WARDEN Supreme integrated key attestation suite")

--- a/supreme/common/build.gradle.kts
+++ b/supreme/common/build.gradle.kts
@@ -60,6 +60,7 @@ kotlin {
         jvmMain.dependencies {
             api(libs.yamltk)
             api(serialization("json"))
+            implementation(bouncycastle("bcpkix"))
         }
 
         jvmTest.dependencies {

--- a/supreme/common/src/commonMain/kotlin/parser/AuthorizationList.kt
+++ b/supreme/common/src/commonMain/kotlin/parser/AuthorizationList.kt
@@ -46,8 +46,8 @@ import kotlin.time.Instant
  *
  * #### Structural Properties and Design Decisions
  * **Structurally, this data structure follows the ASN.1 schema _exactly_**, meaning that it is a structural 1:1 mapping
- * if the underlying ASN.1 structure.
- * This as both advantages and disadvantages. The main disadvantage is that it is a bit cumbersome to use. The benefits
+ * of the underlying ASN.1 structure.
+ * This has both advantages and disadvantages. The main disadvantage is that it is a tiny bit cumbersome to use. The benefits
  * far outweigh the shortcomings of this approach, though:
  * * Just check the schema, and you know what's what. That means that there are no booleans, but an object indicating
  * `true` or `false` is either present or absent.
@@ -66,6 +66,12 @@ import kotlin.time.Instant
  * - The public API still exposes these values as regular Kotlin [Set]s.
  * - When encoding, if such an order-preserving set is present, the produced ASN.1 SET preserves that iteration order
  *   (which may be non-DER-compliant). Otherwise, normal SET encoding is used.
+ *
+ * #### Repeated Tags
+ * Although the schema permits each tag only once, some Android 16 devices emit repeated singleton tags. When all
+ * occurrences encode the same value, the corresponding property returns that value. When they disagree, it returns an
+ * [AttestationValue.Failure] instead of selecting an arbitrary occurrence. Repeated set-valued tags follow the same
+ * rule: identical sets are returned, while conflicting sets produce a set containing a failure.
  *
  */
 data class AuthorizationList private constructor(

--- a/supreme/config-hoplite/build.gradle.kts
+++ b/supreme/config-hoplite/build.gradle.kts
@@ -49,15 +49,16 @@ pitest {
     verbose.set(false)
 }
 
-val javadocJar = setupDokka(
+setupDokka(
     baseUrl = "https://github.com/a-sit-plus/warden-supreme/tree/main",
 )
+val javadocRedirectJar = tasks.named<Jar>("javadocRedirectJar")
 
 publishing {
     publications {
         register("mavenJava", MavenPublication::class) {
             from(components["java"])
-            artifact(javadocJar)
+            artifact(javadocRedirectJar)
             pom {
                 name.set("Warden Config Hoplite")
                 description.set("Hoplite integration helpers for Warden Supreme configuration")
@@ -88,7 +89,7 @@ publishing {
             }
         }
         withType<MavenPublication> {
-            if (this.name != "relocation" && this.name != "mavenJava") artifact(javadocJar)
+            if (this.name != "relocation" && this.name != "mavenJava") artifact(javadocRedirectJar)
             pom {
                 name.set("Warden Config Hoplite")
                 description.set("Hoplite integration helpers for Warden Supreme configuration")

--- a/supreme/config-spring/build.gradle.kts
+++ b/supreme/config-spring/build.gradle.kts
@@ -48,15 +48,16 @@ pitest {
     verbose.set(false)
 }
 
-val javadocJar = setupDokka(
+setupDokka(
     baseUrl = "https://github.com/a-sit-plus/warden-supreme/tree/main/supreme",
 )
+val javadocRedirectJar = tasks.named<Jar>("javadocRedirectJar")
 
 publishing {
     publications {
         register("mavenJava", MavenPublication::class) {
             from(components["java"])
-            artifact(javadocJar)
+            artifact(javadocRedirectJar)
             pom {
                 name.set("Warden Config Spring")
                 description.set("Spring Boot integration helpers for Warden Supreme configuration")
@@ -87,7 +88,7 @@ publishing {
             }
         }
         withType<MavenPublication> {
-            if (this.name != "relocation" && this.name != "mavenJava") artifact(javadocJar)
+            if (this.name != "relocation" && this.name != "mavenJava") artifact(javadocRedirectJar)
             pom {
                 name.set("Warden Config Spring")
                 description.set("Spring Boot integration helpers for Warden Supreme configuration")

--- a/supreme/verifier/build.gradle.kts
+++ b/supreme/verifier/build.gradle.kts
@@ -53,14 +53,15 @@ kotlin {
     }
 }
 
-val javadocJar = setupDokka(
+setupDokka(
     baseUrl = "https://github.com/a-sit-plus/warden-supreme/tree/main/supreme",
 )
+val javadocRedirectJar = tasks.named<Jar>("javadocRedirectJar")
 
 publishing {
     publications {
         withType<MavenPublication> {
-            if (this.name != "relocation") artifact(javadocJar)
+            if (this.name != "relocation") artifact(javadocRedirectJar)
             pom {
                 name.set("Warden Supreme Verifier")
                 description.set("Server-Side attestation verifier; part of the WARDEN Supreme integrated key attestation suite")

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-additional-verifications.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-additional-verifications.kt
@@ -15,6 +15,7 @@ private suspend fun foo() {
 
 
 
+// --8<-- [start:additional-verifications]
 val response = verifier.verifyAttestation(
  /*(1)!*/attestationProof = proof,
  /*(2)!*/additionalVerifications = { receivedProof, _ ->
@@ -31,6 +32,7 @@ val response = verifier.verifyAttestation(
  /*(6)!*/certificateIssuer = { verifiedProof ->
         issueCertificateChain(verifiedProof)
     }
+// --8<-- [end:additional-verifications]
 )
 
 

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-callbacks.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-callbacks.kt
@@ -15,6 +15,7 @@ private suspend fun foo() {
 
 
 
+// --8<-- [start:verifier-callbacks]
 val result = verifier.verifyAttestation(
  /*(1)!*/attestationProof = proof,
  /*(2)!*/onChallengeValidated = { receivedProof ->
@@ -54,6 +55,7 @@ val result = verifier.verifyAttestation(
     }
     TODO("Refer to minimum example for certificate issuance")
 }
+// --8<-- [end:verifier-callbacks]
 
 
 

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-errorhandling.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-errorhandling.kt
@@ -14,6 +14,7 @@ private val logger = Logger.getLogger("demo")
 private suspend fun foo() {
 
 
+    // --8<-- [start:attestation-error-handling]
     val result = verifier.verifyAttestation(
         csr = csr,
         onAttestationError = { debugStatement ->
@@ -48,6 +49,7 @@ private suspend fun foo() {
             }
         }
     ) { TODO("Refer to minimum example for certificate issuance") }
+    // --8<-- [end:attestation-error-handling]
 
 
 

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-preerrorhandling.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend-preerrorhandling.kt
@@ -13,6 +13,7 @@ private suspend fun foo() {
 
 
 
+// --8<-- [start:pre-attestation-error-handling]
 val result = verifier.verifyAttestation(
     attestationProof = proof,
     onPreAttestationError = {
@@ -36,6 +37,7 @@ val result = verifier.verifyAttestation(
         }
     }
 ) { TODO("Refer to minimum example for certificate issuance") }
+// --8<-- [end:pre-attestation-error-handling]
 
 
 

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Backend.kt
@@ -58,6 +58,7 @@ val caCert: X509Certificate = TODO()
 
 
 
+// --8<-- [start:backend-server]
 val server = embeddedServer(Netty, port = 8080) {
    /*(1)!*/install(ContentNegotiation) { json() }
 
@@ -88,3 +89,4 @@ val server = embeddedServer(Netty, port = 8080) {
         }
     }
 }.start(wait = false)
+// --8<-- [end:backend-server]

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config-Graphene.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config-Graphene.kt
@@ -12,6 +12,7 @@ const val androidAppPackage = "at.asitplus.atttest"
 
 
 
+// --8<-- [start:grapheneos-config]
 
 val grapheneOsVerifiedBootKeys = setOf(
     "d8f879d10419eddc9fcda6280718be763f6bf12299e1f72df3ea8ad8a8eb7f80",
@@ -49,3 +50,4 @@ val grapheneOsConfig = SupremeConfiguration(
         allowBootloaderUnlock = false /*(3)!*/
     )
 )
+// --8<-- [end:grapheneos-config]

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config-Hoplite.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config-Hoplite.kt
@@ -12,6 +12,7 @@ import com.sksamuel.hoplite.ExperimentalHoplite
 private fun readmeHopliteConfigExample() {
 
 
+// --8<-- [start:hoplite-config-loader]
 val loader = ConfigLoaderBuilder.default()
     .withExplicitSealedTypes()
     .addDecoder(AndroidAttestationConfiguration.hopliteDecoder())
@@ -23,6 +24,7 @@ val config: SupremeConfiguration = loader.loadConfigOrThrow()
 
 
 
+// --8<-- [end:hoplite-config-loader]
 
 
 

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config-min.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config-min.kt
@@ -5,6 +5,7 @@ import at.asitplus.attestation.Makoto
 import at.asitplus.attestation.android.AndroidAttestationConfiguration
 import at.asitplus.attestation.android.parseHex
 
+// --8<-- [start:minimal-makoto-config]
 val makoto = Makoto(
     androidAttestationConfiguration = AndroidAttestationConfiguration(
      /*(1)!*/AndroidAttestationConfiguration.AppData(
@@ -19,3 +20,4 @@ val makoto = Makoto(
         )
     )
 )
+// --8<-- [end:minimal-makoto-config]

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Config.kt
@@ -12,6 +12,7 @@ import kotlin.time.Duration.Companion.minutes
 val myCustomRoots = APPLE_DEFAULT_TRUSTED_ROOTS
 
 
+// --8<-- [start:makoto-config]
 val makoto = Makoto(
     androidAttestationConfiguration = AndroidAttestationConfiguration(
         applications = listOf(
@@ -77,3 +78,4 @@ val makoto = Makoto(
     clock = Clock.System, //DEFAULT
  /*(28)!*/verificationTimeOffset = 5.minutes, //OPTIONAL, defaults shown
 )
+// --8<-- [end:makoto-config]

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Raw-ios-assertion.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Raw-ios-assertion.kt
@@ -32,6 +32,7 @@ object RawIosAssertionExample {
 
 
 
+        // --8<-- [start:ios-assertion-verification]
         val registration = /*(1)!*/makoto.ios.verifyAppAttestation(attestationObject, challengeAtRegistration)
         val verified = /*(2)!*/registration as AttestationResult.IOS.Verified
 
@@ -58,6 +59,7 @@ object RawIosAssertionExample {
             expectedChallenge = expectedChallenge,
             validCounters = (previousCounter - 1)..previousCounter
         )
+        // --8<-- [end:ios-assertion-verification]
 
 
 

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-config-supreme.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-config-supreme.kt
@@ -13,7 +13,9 @@ private val configuration: SupremeConfiguration =
 
 
 
+// --8<-- [start:verifier-from-supreme-config]
 val verifierFromConfig = AttestationVerifier(
     configuration,
  /*(1)!*/WardenDefaults.nonceGenerator
 ) {/*(2)!*/clock, offset -> InMemoryChallengeCache(clock, offset) }
+// --8<-- [end:verifier-from-supreme-config]

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-config.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-config.kt
@@ -1,0 +1,64 @@
+package examples.docs.config.supreme
+
+import at.asitplus.attestation.supreme.AttestationChallenge
+import at.asitplus.attestation.supreme.AttestationChallengeValidator
+import at.asitplus.attestation.supreme.AttestationVerifier
+import at.asitplus.attestation.supreme.DataAuthentication
+import at.asitplus.attestation.supreme.KeyConstraints
+import at.asitplus.attestation.supreme.KeyConstraints.AlgorithmParameters
+import at.asitplus.attestation.supreme.KeyConstraints.KeyProtection
+import at.asitplus.attestation.supreme.PrimitiveType
+import at.asitplus.attestation.supreme.SupremeConfiguration
+import at.asitplus.attestation.supreme.WardenDefaults
+import at.asitplus.signum.indispensable.ECCurve
+import at.asitplus.signum.indispensable.Digest
+import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import at.asitplus.signum.indispensable.nativeDigest
+import examples.docs.config.minimal.makoto
+import org.kotlincrypto.random.CryptoRand
+import kotlin.time.Duration.Companion.seconds
+
+val redisBacked: AttestationChallengeValidator = TODO()
+val serviceSpecificOID = WardenDefaults.OIDs.ATTESTATION_PROOF
+// UUID-derived example OID (UUID e4da8413-46ae-4f0f-88f5-c7325b5850b0)
+val customerAttributesOID = ObjectIdentifier("2.25.304198582559398858370235454530489176240")
+
+
+
+
+
+
+// --8<-- [start:verifier-config-supreme]
+val configuration = SupremeConfiguration(
+ /*(1)!*/android = makoto.androidAttestationConfiguration!!,
+    ios = makoto.iosAttestationConfiguration!!,
+ /*(2)!*/attestationProofOID = serviceSpecificOID, //override default
+ /*(3)!*/genericDeviceNameOID = null, //WardenDefaults.OIDs.DEVICE_NAME by default
+ /*(4)!*/defaultKeyConstraints = KeyConstraints(
+        algorithmParameters = AlgorithmParameters.EC(
+            curve = ECCurve.SECP_256_R_1,
+            digests = setOf(ECCurve.SECP_256_R_1.nativeDigest),
+            allowKeyAgreement = false //DEFAULT
+        ),
+ /*(5)!*/keyProtection = KeyProtection(
+            timeout = 30.seconds,
+            deviceLock = false,
+            biometry = true,
+            allowNewBiometricFactors = false,
+        )
+    ),
+ /*(6)!*/toBeAttestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
+        customerAttributesOID,
+        listOf(
+            AttestationChallenge.AttributeAttestationDescriptor("accountId", PrimitiveType.STRING),
+            AttestationChallenge.AttributeAttestationDescriptor("riskScore", PrimitiveType.INT, required = false),
+        ),
+    ),
+ /*(7)!*/dataAuth = DataAuthentication.Hash(Digest.SHA256),
+)
+
+val verifier = AttestationVerifier(
+    configuration,
+ /*(8)!*/nonceGenerator = suspend { CryptoRand.nextBytes(ByteArray(/*(9)!*/128)) },
+) {/*(10)!*/clock, offset -> redisBacked }
+// --8<-- [end:verifier-config-supreme]

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-min.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-min.kt
@@ -1,4 +1,6 @@
 package examples.docs.config.minimal
 import at.asitplus.attestation.supreme.AttestationVerifier
 
+// --8<-- [start:minimal-verifier]
 val verifier = AttestationVerifier(makoto)/*(1)!*/
+// --8<-- [end:minimal-verifier]

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier.kt
@@ -28,6 +28,7 @@ val customerAttributesOID = ObjectIdentifier("2.25.30419858255939885837023545453
 
 
 
+// --8<-- [start:verifier-config]
 val verifier = AttestationVerifier(
     makoto = makoto,
  /*(1)!*/attestationProofOID = serviceSpecificOID, //override default
@@ -57,3 +58,4 @@ val verifier = AttestationVerifier(
     ),
  /*(8)!*/dataAuth = DataAuthentication.Hash(Digest.SHA256),
 )
+// --8<-- [end:verifier-config]


### PR DESCRIPTION
* Remove Deprecations schedules for removal in 1.1
* Deprecate APIs with rough edges (will be removed in Warden Supreme 1.3)
* **Rework iOS App Attest assertion validation**
    * Add `validateAssertionOverChallenge` for assertions whose complete client data is the server challenge.
    * Add `validateAssertion` with a caller-provided `AssertionChallengeValidator` for arbitrary client data.
    * Replace counter ranges with explicit `lastSeenCounter` and `maxCounterAdvance` parameters.
    * Deprecate the legacy `verifyAssertion` overloads for removal in Warden Supreme 1.3.
    * Clarify challenge binding for standalone and combined attestation/assertion validation, and expand coverage for
      wrong challenges, mismatched client data, custom validators, and counter bounds.
* **Selectable attestation-proof authentication and attested client attributes**
    * Add `DataAuthentication.Signature` (default) and `DataAuthentication.Hash` challenge modes.
    * Signature mode preserves the existing signed-PKCS#10 behaviour and proof-of-possession check.
    * Hash mode returns an unsigned TBS CSR and binds its version, subject, extensions, and non-proof attributes through
      a canonical DER hash used as the platform attestation nonce. It deliberately does not prove possession.
    * Always verify that the public key in the received TBS CSR matches the key proven by the platform attestation.
    * Add `AttestationProof` as the verifier/client transport abstraction and structurally decode its DER as either
      a complete CSR or TBS CSR. Hash algorithms remain challenge-owned and are never supplied with client transport.
      Deprecate CSR-only overloads; they reject hash authentication and requested attributes instead of silently changing
      behaviour.
    * Add ordered required/optional client-provided attributes using `toBeAttestedAttributes`.
      Values are authenticated by either supported mode.
    * Move authentication selection from optional `KeyConstraints` into `AttestationChallenge`.
    * Add canonical `AttestationHashInput` conversion to and from TBS CSR data, excluding only the public key and exactly
      one attestation-proof attribute.
    * Reject authentication-mode mismatches, duplicate CSR attribute/extension OIDs, malformed extension requests,
      non-canonical attribute order, key mismatches, and missing or invalid requested attributes.
    * Route all new verifier validation failures through `onPreAttestationError` as typed
      `PreAttestationError.ClientDataValidation` values.
    * Add `dataAuthentication` and human-readable `toBeAttestedAttributes` support to `SupremeConfiguration` JSON/YAML.
    * Expand client, verifier, property, and Android-emulator end-to-end coverage for both authentication modes and
      required/optional attribute combinations.
    * Bump ChallengeVersion to 3, but still transmit 2, of DataAuthentication.Signature is used without any requested to-be-attested attributes  
      **This keeps compatibility between non-aligned clients and verifiers across Warden Supreme 1.0 and 1.1.**
* Add Supreme dependency to `supreme-common`
* Dependency Updates:
    * Bouncy Castle 1.85
    * Signum Indispensable 3.25.0