### PR TITLE
Fix missing slash in announce box

### DIFF
--- a/docs/overrides/partials/announce.html
+++ b/docs/overrides/partials/announce.html
@@ -4,6 +4,6 @@
   </style>
 {% else %}
   <div class="md-announce__inner">
-    Need help tailored to your needs? See our <a href="{{ config.site_url }}services/">&ensp;💎 Services</a>.
+    Need help tailored to your needs? See our <a href="{{ config.site_url }}/services/">&ensp;💎 Services</a>.
   </div>
 {% endif %}


### PR DESCRIPTION
Fix, so that resulting link is not `https://a-sit-plus.github.io/warden-supreme/1.1.0services/`