### PR TITLE
Fix/error confusion

### DIFF
--- a/.github/workflows/test-manually.yml
+++ b/.github/workflows/test-manually.yml
@@ -41,7 +41,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Build jar
-        run: ./gradlew :makoto:test :roboto:test assemble
+        run: ./gradlew test jvmTest assemble
       - name: Test Report
         uses: dorny/test-reporter@v2
         if: success() || failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## NEXT
+* Fix: Preserve the meaningful Android attestation failure when both hardware and software verification fail, instead of masking it with a trust-anchor mismatch from the wrong verification engine.
+* Clarify debugging
 
 ## 1.1.2
 * Fix: Include the Android revocation-list snapshot used during certificate-chain validation in debug statements and reuse it during replay.

--- a/docs/docs/integration/debugging.md
+++ b/docs/docs/integration/debugging.md
@@ -6,13 +6,19 @@ verification. Warden Supreme can capture these inputs and replay the failed chec
 For an interactive look at real-world Android attestation data before building an integration, use the
 [Attestation Collector](../collector.md). It displays the parsed statement and verification result.
 
-The approach is the same whether you use Warden Supreme's integrated attestation flow or the raw _makoto_ or _roboto_
-attestation checkers (see [Usage without Integrated Clients](raw.md)):
-- Use Warden Supreme’s `collectDebugInfo(...)` on attestation errors to capture inputs, parsed fields, decisions, and failure reasons.
-- Persist the debug info object via `serialize()` / `serializeCompact()` to logs.
-- Enrich logs with device make/model, OS and patch levels, so OEM‑specific quirks can be correlated over time.
-- Replay collected debug statements offline to analyse attestation failures by invoking `replay()` on a collected debug statement
-  (see [Debugging Integrated Attestation](#debugging-integrated-attestation)).
+The workflow is the same whether you use Warden Supreme's integrated flow or the raw _makoto_ or _roboto_ attestation
+checkers (see [Usage without Integrated Clients](raw.md)):
+
+1. When verification fails, capture a debug statement containing the exact proof, configuration, verification time, and
+   revocation-list snapshot used for the check.
+2. Call `serializeCompact()` on that statement and persist the resulting single-line string. This is the portable replay
+   artifact to copy from the deployed service to a development machine.
+3. Deserialize the compact string and call `replay()` locally. The original check can then be stepped through in a debugger
+   without access to the device or the original deployment.
+4. Use `serialize()` only when you want a human-readable JSON representation for inspection.
+
+Enrich the surrounding log entry with device make/model, OS, and patch levels so OEM-specific quirks can be correlated over
+time.
 
 !!! warning "Privacy Risks and Risk of Chasing Phantoms"
     Three restrictions apply when recording or sharing debug statements.
@@ -28,20 +34,37 @@ attestation checkers (see [Usage without Integrated Clients](raw.md)):
           and share debug statements for analysis, while `serialize()` is for a human-readable representation.
 
 ## Collecting Debug Info
-Warden Supreme's integrated flow already offers a hook to collect debug statements:
-Whenever the actual attestation check fails (i.e., whenever `onAttestationError()` is called), a ready-made `WardenDebugAttestationStatement` is created and passed to this function.
-The callback provides two pieces of diagnostic information:
 
-1. The attestation error (as the receiver of this lambda)
-2. The debug statement, which can be exported for offline analysis
+Regardless of whether you are using Warden Supreme's integrated attestation flow, or raw makoto/roboto,
+all flows produce a debug statement with the same `serialize()`, `serializeCompact()`, and `replay()` lifecycle. Only
+the point at which the statement is collected and its concrete type differ:
 
-Warden _roboto_ and _makoto_ offer a `collectDebugInfo()` function to the same effect, creating a serializable debug statement.
-The difference is that you call it manually, and the right place and time to call it depends on how _roboto_ or _makoto_ are integrated.
-_makoto_ produces a `WardenDebugAttestationStatement` directly, while _roboto_'s `collectDebugInfo()` returns an `AndroidDebugAttestationStatement`.
-Both expose the same replay function and carry everything needed to replay the attestation check offline.
+| Verification flow | How debug info is obtained                                 | Debug statement type               |
+|-------------------|------------------------------------------------------------|------------------------------------|
+| Warden Supreme    | Supplied automatically to `onAttestationError`             | `WardenDebugAttestationStatement`  |
+| Raw _makoto_      | Call `collectDebugInfo(...)` after the failed verification | `WardenDebugAttestationStatement`  |
+| Raw _roboto_      | Call `collectDebugInfo(...)` after the failed verification | `AndroidDebugAttestationStatement` |
+
+In Warden Supreme's integrated flow, the attestation error is the receiver of the `onAttestationError` lambda and the ready-made
+debug statement is its argument. Persist the compact replay artefact directly in that callback:
+
+```kotlin
+onAttestationError = { debugInfo ->
+    logger.error(debugInfo.serializeCompact())
+    null
+}
+```
+
+With raw _makoto_ or _roboto_, call the matching `collectDebugInfo(...)` overload using the same proof and challenge that were
+passed to verification, then persist `debugInfo.serializeCompact()`. Collect it after the failed verification so the statement
+can include the revocation-list snapshot used by that check.
+
+The resulting compact string is the boundary between production and offline debugging: store or transfer it as one unchanged
+line. Do not copy the pretty-printed `serialize()` output for replay.
 
 ## Debugging Integrated Attestation
-Warden Supreme already contains code to load `WardenDebugAttestationStatement`s and `replay()` them.
+Warden Supreme already contains code to load compact `WardenDebugAttestationStatement`s and `replay()` them. The replay utility
+expects a file containing one `serializeCompact()` result per line.
 Run the replay utility in an IDE to step through the attestation workflow and inspect the stack trace behind a failure:
 
 * Import this project into IntelliJ IDEA
@@ -50,6 +73,17 @@ Run the replay utility in an IDE to step through the attestation workflow and in
 
 Pass the debug-statement file as the single argument described in
 [Diag.kt](https://github.com/a-sit-plus/warden-supreme/tree/main/utils/makoto-diag/src/main/kotlin/Diag.kt).
+
+The equivalent direct API flow is:
+
+```kotlin
+val statement = WardenDebugAttestationStatement.deserializeCompact(recordedLine)
+println(statement.serialize()) // optional human-readable JSON
+val replayedResult = statement.replay()
+```
+
+For a raw _roboto_ recording, use `AndroidDebugAttestationStatement.deserializeCompact(recordedLine)` instead; the remaining
+workflow is identical.
 
 ## Debugging Raw Android Attestations
 

--- a/serverside/roboto/src/main/kotlin/Roboto.kt
+++ b/serverside/roboto/src/main/kotlin/Roboto.kt
@@ -184,8 +184,10 @@ constructor(
                         || (it.exceptionOrNull() is RevocationException)
             }?.exceptionOrNull()?.let { throw it }
 
-            throw results.last() //this way we are most lenient
-                .exceptionOrNull()!!
+            throw results.asReversed()
+                .mapNotNull { it.exceptionOrNull() }
+                .firstOrNull { it !is CertificateInvalidException.OtherMatchingRoot }
+                ?: results.last().exceptionOrNull()!!
         } else certificates
     }
 


### PR DESCRIPTION
* Fix: Preserve the meaningful Android attestation failure when both hardware and software verification fail, instead of masking it with a trust-anchor mismatch from the wrong verification engine.
* Clarify debugging