### PR TITLE
Release/1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## NEXT
+## 1.1.3
 * Fix: Preserve the meaningful Android attestation failure when both hardware and software verification fail, instead of masking it with a trust-anchor mismatch from the wrong verification engine.
 * Clarify debugging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.3
 * Fix: Preserve the meaningful Android attestation failure when both hardware and software verification fail, instead of masking it with a trust-anchor mismatch from the wrong verification engine.
 * Clarify debugging
+* Update android keyattestation to 2b0f4f300592a38139d5592ac1c27e2ef70566c2
 
 ## 1.1.2
 * Fix: Include the Android revocation-list snapshot used during certificate-chain validation in debug statements and reuse it during replay.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx8G
 
-artifactVersion=1.2.0-SNAPSHOT
+artifactVersion=1.1.3
 groupId=at.asitplus.warden
 collector.versionCode=3
 


### PR DESCRIPTION
* Fix: Preserve the meaningful Android attestation failure when both hardware and software verification fail, instead of masking it with a trust-anchor mismatch from the wrong verification engine.
* Clarify debugging
* Update android keyattestation to 2b0f4f300592a38139d5592ac1c27e2ef70566c2