### PR TITLE
Feature/improved java interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## NEXT
-* Add Fixed time srouce shorthand in `SupremeConfiguration`
+* Add Fixed time source shorthand in `SupremeConfiguration`
+* More Java-Friendliness all over the place (see docs/integration/java)
+    * Mark Java-Only APIs `internal` and use `@JvmName` to hide them from the public Kotlin API   
 
 ## 1.1.4
 * Fix Spring Boot config loading (which is more cursed than anticipated):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## NEXT
+* Add Fixed time srouce shorthand in `SupremeConfiguration`
 
 ## 1.1.4
 * Fix Spring Boot config loading (which is more cursed than anticipated):

--- a/docs/docs/integration/config.md
+++ b/docs/docs/integration/config.md
@@ -4,6 +4,10 @@
 !!! tip "Configuration Reference"
     For the full configuration reference, see [Attestation Policy Configuration](supreme.md#attestation-policy-configuration).
 
+!!! tip inline end "Configuration from Java"
+    `SupremeConfiguration` accepts `java.time.Clock` and `java.time.Duration`, and its fixed clock accepts a
+    `java.time.Instant`. See [Using Warden Supreme from Java](java.md#configuration-and-time).
+
 Warden Supreme configuration consists of two parts:
 
 1. Attestation policy configuration as explained in [Attestation Policy Configuration](supreme.md#attestation-policy-configuration), split into
@@ -186,7 +190,20 @@ expose the same (de)serialisation functions as `SupremeConfiguration`.
     --8<-- "supreme.json"
     ```
 
-It is possible to add time sources other than the system clock and externalise their configurations as well by implementing
+!!! tip "Fixed verification time"
+    The examples use `clock: system`, which is the production default. For deterministic tests and replay, configure
+    the built-in fixed time source:
+
+    ```yaml
+    clock:
+      type: fixed # (1)
+      instant: 2025-01-10T12:34:56.789Z # (2)
+    ```
+
+    1. `fixed` selects the serialisable `SupremeConfiguration.Clock.Fixed` implementation.
+    2. `instant` pins verification to one ISO-8601 instant. This representation round-trips through YAML and JSON.
+
+It is also possible to add other time sources and externalise their configurations by implementing
 `SupremeConfiguration.Clock` and registering the classes for serialisation using `SupremeConfiguration.Clock.registry`.
 
 !!! tip "Loading from a file"

--- a/docs/docs/integration/debugging.md
+++ b/docs/docs/integration/debugging.md
@@ -35,6 +35,10 @@ time.
 
 ## Collecting Debug Info
 
+!!! tip inline end "Java Back-Ends"
+    The Java verifier callback receives the ready-made debug statement directly. Raw _makoto_ and _roboto_ expose
+    synchronous `collectDebugInfo(...)` methods. See [Using Warden Supreme from Java](java.md) for their Java signatures.
+
 Regardless of whether you are using Warden Supreme's integrated attestation flow, or raw makoto/roboto,
 all flows produce a debug statement with the same `serialize()`, `serializeCompact()`, and `replay()` lifecycle. Only
 the point at which the statement is collected and its concrete type differ:

--- a/docs/docs/integration/java.md
+++ b/docs/docs/integration/java.md
@@ -1,0 +1,1 @@
+# Java Interop

--- a/docs/docs/integration/java.md
+++ b/docs/docs/integration/java.md
@@ -1,1 +1,110 @@
-# Java Interop
+# Using Warden Supreme from Java
+
+Warden Supreme is written in Kotlin, but its server-side JVM modules can also be used from Java. The regular data model
+and configuration classes are directly accessible; small Java-facing adapters bridge the places where the Kotlin API
+uses suspending functions, receiver lambdas, or Kotlin time types.
+
+!!! info "Java-only API"
+    Java-only adapters are deliberately marked `internal` in Kotlin source so they do not clutter the Kotlin API.
+    Kotlin/JVM still emits them as public JVM declarations, and `@JvmName` gives their methods stable, idiomatic Java
+    names. The examples on this page are compiled and exercised from the Java test source set.
+
+## Integrated Attestation
+
+For a new integration, use `JavaAttestationVerifier`. It wraps the Kotlin-first `AttestationVerifier` and exposes:
+
+* regular methods instead of suspending functions
+* an ordinary `Callbacks` interface instead of Kotlin receiver lambdas and `FunctionN` types
+* `CompletableFuture` results for challenge issuance and attestation verification
+
+The following complete example is compiled as part of the JVM test suite:
+
+```java
+--8<-- "SupremeVerifierJavaApi.java:java-example-verifier"
+```
+
+1. Configure the iOS application using the regular Java constructor.
+2. Create the platform and integrated policy through the Java-friendly configuration helper shown below.
+3. Implement the regular Java callback interface. The challenge has already been validated when this callback runs.
+4. Successful verification provides both the verified platform result and the attested public key.
+5. Return `null` to accept the proof after application-specific checks, or return an `AttestationResponse.Failure` to
+   reject it.
+6. Return the certificate chain issued for the attested key. An empty list is useful only when exercising an error path,
+   as this test example does.
+7. Keep one verifier instance and compose the returned futures at the application's asynchronous boundary.
+
+!!! tip "Working with `CompletableFuture`"
+    Use `thenApply`, `thenCompose`, or `exceptionally` to continue asynchronously. `join()` is convenient at a genuinely
+    synchronous boundary, but must not block an event-loop thread.
+
+## Configuration and Time
+
+`SupremeConfiguration` provides a Java-friendly constructor with nullable iOS and Android policies followed by Java
+standard-library time types:
+
+```java
+--8<-- "SupremeVerifierJavaApi.java:java-example-configuration"
+```
+
+1. Pass the iOS policy, or `null` for an Android-only verifier.
+2. Pass the Android policy, or `null` for an iOS-only verifier. At least one platform policy must be present.
+3. Supply the clock used for verification. `Clock.systemUTC()` is the default.
+4. Set the verification-time offset used to compensate for clock drift. The default is five minutes.
+
+The constructor uses `@JvmOverloads`, so trailing arguments can be omitted when their defaults are suitable. In
+particular, `new SupremeConfiguration(iosConfiguration, androidConfiguration)` uses the system UTC clock and the default
+verification-time offset.
+
+For deterministic tests, construct a serialisable fixed clock with
+`new SupremeConfiguration.Clock.Fixed(java.time.Instant)`. An existing Java clock can also be adapted with
+`SupremeConfiguration.Clock.from(java.time.Clock)`.
+
+!!! note "Clocks in externalised configuration"
+    `Clock.Fixed` and the system clock have canonical YAML and JSON representations. A clock created with `Clock.from(...)`
+    is a runtime adapter and should not be written to externalised configuration. See
+    [Externalising Configuration](config.md) for the supported formats.
+
+## Using Makoto or Roboto Directly
+
+The integrated flow above is the recommended path. The APIs in this section are useful when the application owns its
+wire format and calls [_Warden makoto_ or _Warden roboto_ directly](raw.md).
+
+### _Warden makoto_
+
+`Makoto` provides Java constructors for combined, Android-only, and iOS-only policies:
+
+* `Makoto(IosAttestationConfiguration, AndroidAttestationConfiguration, java.time.Duration, java.time.Clock)`
+* `Makoto(AndroidAttestationConfiguration, java.time.Duration, java.time.Clock)`
+* `Makoto(IosAttestationConfiguration, java.time.Duration, java.time.Clock)`
+
+All three use `@JvmOverloads`; the trailing duration and clock can therefore be omitted. The combined constructor
+requires both policies, while the platform-specific constructors configure only their named platform.
+
+The most useful synchronous Java methods are:
+
+* `verifyKeyAttestation(Attestation, byte[])` for the unified key-attestation representation
+* `getAndroid().verifyKeyAttestationBlocking(List<X509Certificate>, byte[])` for a raw Android certificate chain
+* `getIos().verifyAppAttestation(byte[], byte[])` for an App Attest object and challenge
+* `getIos().verifyCombined(byte[], byte[], byte[], byte[])` for App Attest plus assertion verification
+* the `collectDebugInfo(...)` overload matching the failed verification call
+
+The first method is named `verifyKeyAttestationBlocking` in Kotlin source, but Java sees
+`verifyKeyAttestation(...)` through `@JvmName`. Overloads accepting the legacy `List<byte[]>` proof format are deprecated
+and should only be used while migrating an existing integration.
+
+### _Warden roboto_
+
+Construct `Roboto` with an `AndroidAttestationConfiguration`. A second constructor accepting a Kotlin `Function2` is
+visible on the JVM, but the one-argument overload provides the intended Java experience and compares challenge bytes by
+content.
+
+Java can then call:
+
+* `verifyBlocking(List<X509Certificate>, java.time.Instant, byte[])`, or omit the instant to use the current time
+* `collectDebugInfo(List<X509Certificate>, byte[], java.time.Instant)`
+* `collectDebugInfo(List<X509Certificate>, byte[], java.util.Date)`
+* `collectDebugInfoBlocking(List<X509Certificate>, byte[], java.time.Instant)`, or omit the instant
+
+The two `collectDebugInfo(...)` overloads are hidden from the public Kotlin API, while being exposed to Java.
+The similarly named top-level Kotlin extension functions are emitted on
+`RobotoKt`, use Kotlin time types, and are not intended as the Java entry point, but for calling from Kotlin.

--- a/docs/docs/integration/raw.md
+++ b/docs/docs/integration/raw.md
@@ -27,6 +27,11 @@ This page also documents _Warden makoto_ (previously WARDEN) and _Warden roboto_
 deployments that have not yet adopted the integrated flow. See the [migration notes](migration.md) when moving between
 the APIs.
 
+!!! tip inline end "Calling these APIs from Java"
+    _Makoto_ and _roboto_ provide Java time constructors and synchronous verification helpers. Their exact Java
+    signatures, including names changed with `@JvmName`, are collected in the
+    [Java interoperability guide](java.md#using-makoto-or-roboto-directly).
+
 !!! tip "Hybrid Integration"
     It is possible to use Warden Supreme's verifier with custom clients by adhering to the [same flows](supreme.md#high-level-attestation-flow) and [data model](datamodel.md).
 

--- a/docs/docs/integration/supreme.md
+++ b/docs/docs/integration/supreme.md
@@ -325,6 +325,10 @@ The in-memory loader, on the other hand, will only ever serve a single, static p
 
 ### Attestation Verifier Setup
 
+!!! tip inline end "Java back-end?"
+    Use `JavaAttestationVerifier` for `CompletableFuture`-based verification and ordinary Java callbacks. The dedicated
+    [Java interoperability guide](java.md) contains a complete, compiled example.
+
 First, an `AttestationVerifier` instance needs to be created based on a `Makoto` instance:
 
 ??? info inline end "Important Nonce Info"
@@ -361,22 +365,25 @@ First, an `AttestationVerifier` instance needs to be created based on a `Makoto`
     1. Android and iOS attestation policies. Here they are lifted from the `Makoto` instance configured above, but you can
        equally construct the `AndroidAttestationConfiguration` and `IosAttestationConfiguration` directly or load them from
        externalised configuration.
-    2. We want Warden Supreme to convey the attestation statement payload inside the TBS CSR using a custom OID.
-    3. We don't care about device names in this example and don't require it from the client.
-    4. We explicitly specify the key we want to have created on the client.  
+    2. The system clock is the default verification time source. For deterministic tests and replay, use the new
+       serialisable `SupremeConfiguration.Clock.Fixed(Instant)`; both system and fixed clocks round-trip through the
+       canonical YAML and JSON configuration formats.
+    3. We want Warden Supreme to convey the attestation statement payload inside the TBS CSR using a custom OID.
+    4. We don't care about device names in this example and don't require it from the client.
+    5. We explicitly specify the key we want to have created on the client.
        The values shown here correspond to the defaults, as this is supported by Android and iOS.
-    5. We require user authentication to use the private key:
+    6. We require user authentication to use the private key:
         * Protected by biometric auth
         * Usable for 30 seconds without reauthentication
         * Enrolling new biometric factors will invalidate the key
-    6. Request two application-provided values under one dedicated attribute OID. `accountId` is required; `riskScore`
+    7. Request two application-provided values under one dedicated attribute OID. `accountId` is required; `riskScore`
        may be omitted as `null`. Order and type are part of the schema.
-    7. Authenticate the TBS CSR data by hashing it with SHA-256 and feeding the digest into platform attestation. Set
+    8. Authenticate the TBS CSR data by hashing it with SHA-256 and feeding the digest into platform attestation. Set
        `DataAuthentication.Signature` (the default) when proof of possession is required.
-    8. A custom nonce generator passed to the verifier. The nonce generator and challenge validator are not part of the
+    9. A custom nonce generator passed to the verifier. The nonce generator and challenge validator are not part of the
        `SupremeConfiguration`, since they are runtime services rather than policy.
-    9. We want extra long nonces (default: 64 bytes; max: 128 bytes).
-    10. Checking and invalidating challenges is handled by a Redis-backed `AttestationChallengeValidator` (not shown here;
+    10. We want extra long nonces (default: 64 bytes; max: 128 bytes).
+    11. Checking and invalidating challenges is handled by a Redis-backed `AttestationChallengeValidator` (not shown here;
         roll your own). This is the recommended approach when multiple verifier instances issue challenges. Omit this
         trailing lambda to use the default bounded in-memory challenge validator.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -119,6 +119,7 @@ markdown_extensions:
       dedent_subsections: true
       base_path:
         - ../supreme/verifier/src/jvmTest/kotlin/examples/
+        - ../supreme/verifier/src/jvmTest/java/examples/
         - ../utils/generator/src/test/kotlin/examples/
         - ../supreme/client/src/commonTest/kotlin/examples/
         - docs/examples/
@@ -159,7 +160,7 @@ nav:
         - Debugging: integration/debugging.md
         - Usage without Integrated Clients: integration/raw.md
         - Migration from WARDEN: integration/migration.md
-        - Java Interop: integration/java.md
+        - Java Interoperability: integration/java.md
         - Changelog: CHANGELOG.md
     - SBOM:
         - Overview: sbom.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
         - Debugging: integration/debugging.md
         - Usage without Integrated Clients: integration/raw.md
         - Migration from WARDEN: integration/migration.md
+        - Java Interop: integration/java.md
         - Changelog: CHANGELOG.md
     - SBOM:
         - Overview: sbom.md

--- a/serverside/roboto/src/main/kotlin/Roboto.kt
+++ b/serverside/roboto/src/main/kotlin/Roboto.kt
@@ -33,7 +33,7 @@ const val OID_RKP = "1.3.6.1.4.1.11129.2.1.30"
  * enabling software attestation accepts software-only attestations as a fallback even while hardware attestation remains
  * enabled. Keep software attestation disabled when hardware backing is required.
  */
-class   Roboto
+class Roboto
 @JvmOverloads
 constructor(
     val attestationConfiguration: AndroidAttestationConfiguration,
@@ -102,7 +102,7 @@ constructor(
      * into a serializable data structure for easy debugging
      */
     @JvmName("collectDebugInfo")
-    fun collectDebugInfoJ(
+    internal fun collectDebugInfoJ(
         certificates: List<X509Certificate>,
         expectedChallenge: ByteArray,
         verificationDate: Date = Date(),
@@ -119,7 +119,7 @@ constructor(
      * into a serializable data structure for easy debugging
      */
     @JvmName("collectDebugInfo")
-    fun collectDebugInfoJ(
+    internal fun collectDebugInfoJ(
         certificates: List<X509Certificate>,
         expectedChallenge: ByteArray,
         verificationDate: java.time.Instant = java.time.Instant.now(),

--- a/supreme/common/src/jvmMain/kotlin/SentinelEmptyListSerializer.kt
+++ b/supreme/common/src/jvmMain/kotlin/SentinelEmptyListSerializer.kt
@@ -54,7 +54,7 @@ open class SentinelEmptyListSerializer<T : Any>(
     override fun serialize(encoder: Encoder, value: List<T>) {
         if (value.isEmpty()) {
             when {
-                isYamlEncoder(encoder) ->
+                encoder.isYamlEncoder() ->
                     encoder.encodeSerializableValue(YamlElement.serializer(), sentinel.toYamlElement())
 
                 encoder is JsonEncoder -> encoder.encodeJsonElement(JsonPrimitive(sentinel))
@@ -68,7 +68,7 @@ open class SentinelEmptyListSerializer<T : Any>(
     }
 
     override fun deserialize(decoder: Decoder): List<T> {
-        if (isYamlDecoder(decoder)) {
+        if (decoder.isYamlDecoder()) {
             val yamlElement = decoder.decodeSerializableValue(YamlElement.serializer())
             if (yamlElement is YamlLiteral && yamlElement.content.matchesSentinel()) return emptyList()
             val json = jsonFor(decoder.serializersModule)

--- a/supreme/common/src/jvmMain/kotlin/YamlFlatteningPolymorphicSerializer.kt
+++ b/supreme/common/src/jvmMain/kotlin/YamlFlatteningPolymorphicSerializer.kt
@@ -38,7 +38,7 @@ open class YamlFlatteningPolymorphicSerializer<T : Any>(
     override val descriptor: SerialDescriptor = polymorphicSerializer.descriptor
 
     override fun serialize(encoder: Encoder, value: T) {
-        if (isYamlEncoder(encoder)) {
+        if (encoder.isYamlEncoder()) {
             val json = jsonFor(encoder.serializersModule)
             val element = json.encodeToJsonElement(polymorphicSerializer, value)
             val flattened = flattenTypeValue(element)
@@ -50,7 +50,7 @@ open class YamlFlatteningPolymorphicSerializer<T : Any>(
     }
 
     override fun deserialize(decoder: Decoder): T {
-        if (isYamlDecoder(decoder)) {
+        if (decoder.isYamlDecoder()) {
             val json = jsonFor(decoder.serializersModule)
             val yamlElement = decoder.decodeSerializableValue(YamlElement.serializer())
             val element = yamlElementToJsonElement(yamlElement)
@@ -61,11 +61,11 @@ open class YamlFlatteningPolymorphicSerializer<T : Any>(
     }
 }
 
-internal fun isYamlEncoder(encoder: Encoder): Boolean =
-    encoder::class.qualifiedName?.startsWith("net.mamoe.yamlkt") == true
+fun Encoder.isYamlEncoder(): Boolean =
+    this::class.qualifiedName?.startsWith("net.mamoe.yamlkt") == true
 
-internal fun isYamlDecoder(decoder: Decoder): Boolean =
-    decoder::class.qualifiedName?.startsWith("net.mamoe.yamlkt") == true
+fun Decoder.isYamlDecoder(): Boolean =
+    this::class.qualifiedName?.startsWith("net.mamoe.yamlkt") == true
 
 internal fun jsonFor(serializersModule: SerializersModule) = Json {
     this.serializersModule = serializersModule

--- a/supreme/verifier/build.gradle.kts
+++ b/supreme/verifier/build.gradle.kts
@@ -1,3 +1,4 @@
+import at.asitplus.gradle.coroutines
 import at.asitplus.gradle.ktor
 import at.asitplus.gradle.setupDokka
 
@@ -37,6 +38,7 @@ kotlin {
             api(project(":makoto"))
             api(project(":supreme-common"))
             implementation(libs.yamltk)
+            implementation(coroutines())
         }
 
         jvmTest {

--- a/supreme/verifier/src/jvmMain/kotlin/JavaAttestationVerifier.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/JavaAttestationVerifier.kt
@@ -17,15 +17,17 @@ import kotlinx.coroutines.launch
  * The verifier itself remains suspend-based. This adapter exposes ordinary Java callback methods and
  * completes a [CompletableFuture] when the asynchronous verification operation finishes.
  */
-class JavaAttestationVerifier(configuration: SupremeConfiguration) {
+internal class JavaAttestationVerifier internal constructor(configuration: SupremeConfiguration) {
 
     private val verifier = AttestationVerifier(configuration)
 
-    fun issueChallenge(endpoint: String): CompletableFuture<AttestationChallenge> = submit {
+    @JvmName("issueChallenge")
+    internal fun issueChallenge(endpoint: String): CompletableFuture<AttestationChallenge> = submit {
         verifier.issueChallenge(endpoint)
     }
 
-    fun verifyAttestation(proof: AttestationProof, callbacks: Callbacks): CompletableFuture<AttestationResponse> =
+    @JvmName("verifyAttestation")
+    internal fun verifyAttestation(proof: AttestationProof, callbacks: Callbacks): CompletableFuture<AttestationResponse> =
         submit {
             verifier.verifyAttestation(
                 attestationProof = proof,
@@ -42,7 +44,7 @@ class JavaAttestationVerifier(configuration: SupremeConfiguration) {
             )
         }
 
-    interface Callbacks {
+    internal interface Callbacks {
         fun onChallengeValidated(challenge: AttestationChallenge, proof: AttestationProof)
 
         fun onPreAttestationError(error: PreAttestationError): String?

--- a/supreme/verifier/src/jvmMain/kotlin/JavaAttestationVerifier.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/JavaAttestationVerifier.kt
@@ -1,0 +1,80 @@
+package at.asitplus.attestation.supreme
+
+import at.asitplus.attestation.AttestationResult
+import at.asitplus.attestation.WardenDebugAttestationStatement
+import at.asitplus.catchingUnwrapped
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.pki.X509Certificate
+import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Java-facing adapter for [AttestationVerifier].
+ *
+ * The verifier itself remains suspend-based. This adapter exposes ordinary Java callback methods and
+ * completes a [CompletableFuture] when the asynchronous verification operation finishes.
+ */
+class JavaAttestationVerifier(configuration: SupremeConfiguration) {
+
+    private val verifier = AttestationVerifier(configuration)
+
+    fun issueChallenge(endpoint: String): CompletableFuture<AttestationChallenge> = submit {
+        verifier.issueChallenge(endpoint)
+    }
+
+    fun verifyAttestation(proof: AttestationProof, callbacks: Callbacks): CompletableFuture<AttestationResponse> =
+        submit {
+            verifier.verifyAttestation(
+                attestationProof = proof,
+                onChallengeValidated = { callbacks.onChallengeValidated(this, proof) },
+                onPreAttestationError = { callbacks.onPreAttestationError(this) },
+                onAttestationError = { debugInfo -> callbacks.onAttestationError(this, debugInfo) },
+                onAttestationSuccess = { publicKey -> callbacks.onAttestationSuccess(this, publicKey) },
+                additionalVerifications = { attestationProof, verified ->
+                    callbacks.additionalVerifications(this, attestationProof, verified)
+                },
+                certificateIssuer = { attestationProof ->
+                    callbacks.certificateIssuer(this, attestationProof)
+                },
+            )
+        }
+
+    interface Callbacks {
+        fun onChallengeValidated(challenge: AttestationChallenge, proof: AttestationProof)
+
+        fun onPreAttestationError(error: PreAttestationError): String?
+
+        fun onAttestationError(
+            error: AttestationResult.Error,
+            debugInfo: WardenDebugAttestationStatement,
+        ): String?
+
+        fun onAttestationSuccess(verified: AttestationResult.Verified, publicKey: CryptoPublicKey)
+
+        fun additionalVerifications(
+            challenge: AttestationChallenge,
+            proof: AttestationProof,
+            verified: AttestationResult.Verified,
+        ): AttestationResponse.Failure?
+
+        fun certificateIssuer(
+            verified: AttestationResult.Verified,
+            proof: AttestationProof,
+        ): List<X509Certificate>
+    }
+
+    private fun <T> submit(block: suspend () -> T): CompletableFuture<T> = CompletableFuture<T>().also { future ->
+        scope.launch {
+            catchingUnwrapped { block() }
+                .onSuccess(future::complete)
+                .onFailure(future::completeExceptionally)
+        }
+    }
+
+    private companion object {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+}

--- a/supreme/verifier/src/jvmMain/kotlin/SupremeConfiguration.kt
+++ b/supreme/verifier/src/jvmMain/kotlin/SupremeConfiguration.kt
@@ -7,15 +7,22 @@ import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifierStringSerializer
 import kotlinx.serialization.*
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.plus
 import net.mamoe.yamlkt.Yaml
+import net.mamoe.yamlkt.YamlElement
+import net.mamoe.yamlkt.YamlLiteral
+import net.mamoe.yamlkt.YamlList
+import net.mamoe.yamlkt.YamlMap
+import net.mamoe.yamlkt.YamlNull
 import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
+import kotlin.time.toKotlinInstant
 
 /**
  * Integrated attestation configuration for the Supreme attestation verifier
@@ -143,6 +150,38 @@ private constructor(
         maxAttestationPayloadBytes,
     )
 
+
+    /**
+     * Java-friendly constructor (although using Java on the back-end kind of defeats the whole point of a shared codebase).
+     * **Note that at least one of [ios], and  [android] must be non-null!**
+     */
+    @Throws(AttestationException.Configuration::class, IllegalArgumentException::class)
+    @JvmOverloads
+    constructor(
+        ios: IosAttestationConfiguration?,
+        android: AndroidAttestationConfiguration?,
+        javaClock: java.time.Clock = java.time.Clock.systemUTC(),
+        verificationTimeOffsetJ: java.time.Duration = Makoto.DEFAULT_TIME_OFFSET.toJavaDuration(),
+        attestationProofOID: ObjectIdentifier = WardenDefaults.OIDs.ATTESTATION_PROOF,
+        genericDeviceNameOID: ObjectIdentifier? = WardenDefaults.OIDs.DEVICE_NAME,
+        defaultKeyConstraints: KeyConstraints? = WardenDefaults.KeyConstraints.p256Signer,
+        dataAuth: DataAuthentication = DataAuthentication.Signature,
+        toBeAttestedAttributes: AttestationChallenge.CertificationRequestAttributeAttestationDescriptor? = null,
+        maxAttestationPayloadBytes: Int = WardenDefaults.DEFAULT_MAX_ATTESTATION_PAYLOAD_BYTES,
+    ) : this(
+        ios=ios,
+        android=android,
+        clock= Clock.from(javaClock),
+        verificationTimeOffset=verificationTimeOffsetJ.toKotlinDuration(),
+        attestationProofOID = attestationProofOID,
+        genericDeviceNameOID = genericDeviceNameOID,
+        defaultKeyConstraints = defaultKeyConstraints,
+        dataAuthentication = dataAuth,
+        toBeAttestedAttributes = toBeAttestedAttributes,
+        maxAttestationPayloadBytes = maxAttestationPayloadBytes,
+    )
+
+
     init {
         require(android != null || ios != null) { "At least one attestation configuration (iOS or Android) must be provided" }
         require(maxAttestationPayloadBytes > 0) { "maxAttestationPayloadSize must be positive" }
@@ -206,8 +245,6 @@ private constructor(
                 if (this === other) return true
                 if (other !is System) return false
 
-                if (timeSource != other.timeSource) return false
-
                 return true
             }
 
@@ -218,9 +255,23 @@ private constructor(
             override fun toString(): String = "System"
         }
 
+        /**
+         * Fixed clock, useful for testing
+         */
+        @Serializable
+        @SerialName("fixed")
+        data class Fixed(val instant: Instant) : Clock {
+            override val timeSource: kotlin.time.Clock
+                get() = FixedTimeClock(instant.toEpochMilliseconds())
+
+            /**
+             * Java-friendly constructor
+             */
+            constructor(javaInstant: java.time.Instant): this(javaInstant.toKotlinInstant())
+        }
+
         object Serializer : KSerializer<Clock> {
-            override val descriptor: SerialDescriptor =
-                PrimitiveSerialDescriptor("SupremeConfiguration.Clock", PrimitiveKind.STRING)
+            override val descriptor: SerialDescriptor = PolymorphicSerializer(Clock::class).descriptor
 
             override fun serialize(encoder: Encoder, value: Clock) {
                 if (value is System) {
@@ -234,16 +285,40 @@ private constructor(
             }
 
             override fun deserialize(decoder: Decoder): Clock {
-                val scalar = catchingUnwrapped { decoder.decodeString() }.getOrNull()
-                if (scalar != null) {
-                    if (scalar.equals("system", ignoreCase = true)) return System
-                    throw SerializationException("Unknown clock value: $scalar")
+                if (decoder is JsonDecoder) {
+                    val element = decoder.decodeJsonElement()
+                    if (element is JsonPrimitive && element.isString) {
+                        if (element.content.equals("system", ignoreCase = true)) return System
+                        throw SerializationException("Unknown clock value: ${element.content}")
+                    }
+                    return json.decodeFromJsonElement(PolymorphicSerializer(Clock::class), element)
                 }
+                if (decoder.isYamlDecoder()) {
+                    val element = decoder.decodeSerializableValue(YamlElement.serializer())
+                    if (element is YamlLiteral) {
+                        if (element.content.equals("system", ignoreCase = true)) return System
+                        throw SerializationException("Unknown clock value: ${element.content}")
+                    }
+                    return json.decodeFromJsonElement(PolymorphicSerializer(Clock::class), element.toJsonElement())
+                }
+                val scalar = catchingUnwrapped { decoder.decodeString() }.getOrNull()
+                if (scalar?.equals("system", ignoreCase = true) == true) return System
+                if (scalar != null) throw SerializationException("Unknown clock value: $scalar")
                 return decoder.decodeSerializableValue(YamlFlatteningPolymorphicSerializer(Clock::class))
             }
         }
 
         companion object {
+
+            @JvmStatic
+            fun from(timeSource:java.time.Clock) = object : Clock {
+                override val timeSource: kotlin.time.Clock                    get() = timeSource.toKotlinClock()
+            }
+
+            fun from(timeSource:kotlin.time.Clock) = object : Clock {
+                override val timeSource: kotlin.time.Clock                    get() = timeSource
+            }
+
             /**
              * Use to register custom [SupremeConfiguration.Clock]s, if you need custom externalised clock configuration.
              * Must be called only once before ever using the registered clock configs.
@@ -255,9 +330,21 @@ private constructor(
             init {
                 //NOOP for our process but useful to keep everything neatly tracked
                 registry.register(SupremeConfiguration.Clock.System::class)
+                //NOOP for our process but useful to keep everything neatly tracked
+                registry.register(SupremeConfiguration.Clock.Fixed::class)
             }
         }
     }
+}
+
+private fun YamlElement.toJsonElement(): JsonElement = when (this) {
+    is YamlMap -> buildJsonObject {
+        content.forEach { (key, value) -> put(key.content.toString(), value.toJsonElement()) }
+    }
+    is YamlList -> buildJsonArray { content.forEach { add(it.toJsonElement()) } }
+    is YamlNull -> JsonPrimitive(null as String?)
+    is YamlLiteral -> JsonPrimitive(content)
+    else -> JsonPrimitive(content?.toString())
 }
 
 private object ConfigurationAttestableAttributesSerializer :

--- a/supreme/verifier/src/jvmTest/java/examples/javaapi/JavaAttestationVerifierTestApi.java
+++ b/supreme/verifier/src/jvmTest/java/examples/javaapi/JavaAttestationVerifierTestApi.java
@@ -1,0 +1,217 @@
+package examples.javaapi;
+
+import at.asitplus.attestation.AttestationResult;
+import at.asitplus.attestation.WardenDebugAttestationStatement;
+import at.asitplus.attestation.supreme.AttestationChallenge;
+import at.asitplus.attestation.supreme.AttestationProof;
+import at.asitplus.attestation.supreme.AttestationResponse;
+import at.asitplus.attestation.supreme.JavaAttestationVerifier;
+import at.asitplus.attestation.supreme.PreAttestationError;
+import at.asitplus.attestation.supreme.SupremeConfiguration;
+import at.asitplus.signum.indispensable.CryptoPublicKey;
+import at.asitplus.signum.indispensable.pki.X509Certificate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Java-owned test harness. Keeping the adapter and callback implementation on this side of the
+ * language boundary ensures the tests compile against the API exactly as a Java consumer does.
+ */
+public final class JavaAttestationVerifierTestApi {
+    private JavaAttestationVerifierTestApi() {
+    }
+
+    public static final class Harness {
+        private final JavaAttestationVerifier verifier;
+
+        public Harness(SupremeConfiguration configuration) {
+            verifier = new JavaAttestationVerifier(configuration);
+        }
+
+        public CompletableFuture<AttestationChallenge> issueChallenge(String endpoint) {
+            return verifier.issueChallenge(endpoint);
+        }
+
+        public CompletableFuture<AttestationResponse> verify(
+                AttestationProof proof,
+                RecordingCallbacks callbacks
+        ) {
+            return verifier.verifyAttestation(proof, callbacks);
+        }
+    }
+
+    public static final class RecordingCallbacks implements JavaAttestationVerifier.Callbacks {
+        private final List<String> calls = new ArrayList<>();
+        private List<X509Certificate> certificates = Collections.emptyList();
+        private AttestationResponse.Failure additionalFailure;
+        private RuntimeException issuerException;
+        private String preErrorExplanation;
+        private String attestationErrorExplanation;
+        private boolean throwOnChallengeValidated;
+        private boolean throwOnAttestationSuccess;
+
+        private AttestationChallenge validatedChallenge;
+        private AttestationProof validatedProof;
+        private PreAttestationError preAttestationError;
+        private AttestationResult.Error attestationError;
+        private WardenDebugAttestationStatement debugInfo;
+        private AttestationChallenge additionalChallenge;
+        private AttestationProof additionalProof;
+        private AttestationResult.Verified additionalVerified;
+        private AttestationResult.Verified issuerVerified;
+        private AttestationProof issuerProof;
+        private AttestationResult.Verified successfulVerified;
+        private CryptoPublicKey successfulPublicKey;
+
+        @Override
+        public void onChallengeValidated(AttestationChallenge challenge, AttestationProof proof) {
+            calls.add("challenge");
+            validatedChallenge = challenge;
+            validatedProof = proof;
+            if (throwOnChallengeValidated) {
+                throw new IllegalStateException("challenge observer exploded");
+            }
+        }
+
+        @Override
+        public String onPreAttestationError(PreAttestationError error) {
+            calls.add("pre-error");
+            preAttestationError = error;
+            return preErrorExplanation;
+        }
+
+        @Override
+        public String onAttestationError(
+                AttestationResult.Error error,
+                WardenDebugAttestationStatement debugInfo
+        ) {
+            calls.add("attestation-error");
+            attestationError = error;
+            this.debugInfo = debugInfo;
+            return attestationErrorExplanation;
+        }
+
+        @Override
+        public void onAttestationSuccess(
+                AttestationResult.Verified verified,
+                CryptoPublicKey publicKey
+        ) {
+            calls.add("success");
+            successfulVerified = verified;
+            successfulPublicKey = publicKey;
+            if (throwOnAttestationSuccess) {
+                throw new IllegalStateException("success observer exploded");
+            }
+        }
+
+        @Override
+        public AttestationResponse.Failure additionalVerifications(
+                AttestationChallenge challenge,
+                AttestationProof proof,
+                AttestationResult.Verified verified
+        ) {
+            calls.add("additional");
+            additionalChallenge = challenge;
+            additionalProof = proof;
+            additionalVerified = verified;
+            return additionalFailure;
+        }
+
+        @Override
+        public List<X509Certificate> certificateIssuer(
+                AttestationResult.Verified verified,
+                AttestationProof proof
+        ) {
+            calls.add("issuer");
+            issuerVerified = verified;
+            issuerProof = proof;
+            if (issuerException != null) {
+                throw issuerException;
+            }
+            return certificates;
+        }
+
+        public List<String> getCalls() {
+            return calls;
+        }
+
+        public void setCertificates(List<X509Certificate> certificates) {
+            this.certificates = certificates;
+        }
+
+        public void setAdditionalFailure(AttestationResponse.Failure additionalFailure) {
+            this.additionalFailure = additionalFailure;
+        }
+
+        public void setIssuerException(RuntimeException issuerException) {
+            this.issuerException = issuerException;
+        }
+
+        public void setPreErrorExplanation(String preErrorExplanation) {
+            this.preErrorExplanation = preErrorExplanation;
+        }
+
+        public void setAttestationErrorExplanation(String attestationErrorExplanation) {
+            this.attestationErrorExplanation = attestationErrorExplanation;
+        }
+
+        public void setThrowOnChallengeValidated(boolean throwOnChallengeValidated) {
+            this.throwOnChallengeValidated = throwOnChallengeValidated;
+        }
+
+        public void setThrowOnAttestationSuccess(boolean throwOnAttestationSuccess) {
+            this.throwOnAttestationSuccess = throwOnAttestationSuccess;
+        }
+
+        public AttestationChallenge getValidatedChallenge() {
+            return validatedChallenge;
+        }
+
+        public AttestationProof getValidatedProof() {
+            return validatedProof;
+        }
+
+        public PreAttestationError getPreAttestationError() {
+            return preAttestationError;
+        }
+
+        public AttestationResult.Error getAttestationError() {
+            return attestationError;
+        }
+
+        public WardenDebugAttestationStatement getDebugInfo() {
+            return debugInfo;
+        }
+
+        public AttestationChallenge getAdditionalChallenge() {
+            return additionalChallenge;
+        }
+
+        public AttestationProof getAdditionalProof() {
+            return additionalProof;
+        }
+
+        public AttestationResult.Verified getAdditionalVerified() {
+            return additionalVerified;
+        }
+
+        public AttestationResult.Verified getIssuerVerified() {
+            return issuerVerified;
+        }
+
+        public AttestationProof getIssuerProof() {
+            return issuerProof;
+        }
+
+        public AttestationResult.Verified getSuccessfulVerified() {
+            return successfulVerified;
+        }
+
+        public CryptoPublicKey getSuccessfulPublicKey() {
+            return successfulPublicKey;
+        }
+    }
+}

--- a/supreme/verifier/src/jvmTest/java/examples/javaapi/SupremeVerifierJavaApi.java
+++ b/supreme/verifier/src/jvmTest/java/examples/javaapi/SupremeVerifierJavaApi.java
@@ -1,38 +1,125 @@
 package examples.javaapi;
 
+import at.asitplus.attestation.AttestationResult;
+import at.asitplus.attestation.AttestationException;
+import at.asitplus.attestation.WardenDebugAttestationStatement;
+import at.asitplus.attestation.android.AndroidAttestationConfiguration;
 import at.asitplus.attestation.supreme.AttestationChallenge;
 import at.asitplus.attestation.supreme.AttestationProof;
 import at.asitplus.attestation.supreme.AttestationResponse;
+import at.asitplus.attestation.IosAttestationConfiguration;
 import at.asitplus.attestation.supreme.JavaAttestationVerifier;
-import at.asitplus.attestation.AttestationResult;
-import at.asitplus.attestation.WardenDebugAttestationStatement;
 import at.asitplus.attestation.supreme.PreAttestationError;
+import at.asitplus.attestation.supreme.SupremeConfiguration;
 import at.asitplus.signum.indispensable.CryptoPublicKey;
 import at.asitplus.signum.indispensable.pki.X509Certificate;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
-/** Java usage of the Java-friendly AttestationVerifier adapter. */
+/** Complete Java usage example for the JavaAttestationVerifier adapter. */
 public final class SupremeVerifierJavaApi {
     private SupremeVerifierJavaApi() {
     }
 
-    public static AttestationChallenge issueChallenge(
+    // --8<-- [start:java-example-configuration]
+    public static SupremeConfiguration newConfiguration(
+            IosAttestationConfiguration ios,
+            AndroidAttestationConfiguration android
+    ) throws AttestationException.Configuration {
+        return new SupremeConfiguration(
+                /*(1)!*/ios,
+                /*(2)!*/android,
+                /*(3)!*/Clock.systemUTC(),
+                /*(4)!*/Duration.ofMinutes(5)
+        );
+    }
+    // --8<-- [end:java-example-configuration]
+
+    // --8<-- [start:java-example-verifier]
+    public static JavaAttestationVerifier newVerifier() throws AttestationException.Configuration {
+        IosAttestationConfiguration ios = new IosAttestationConfiguration(
+                new IosAttestationConfiguration.AppData(
+                        /*(1)!*/"9CYHJNG644",
+                        "at.asitplus.attestation-client"
+                )
+        );
+
+        SupremeConfiguration configuration = /*(2)!*/newConfiguration(ios, null);
+        return new JavaAttestationVerifier(configuration);
+    }
+
+    public static CompletableFuture<AttestationChallenge> issueChallenge(
             JavaAttestationVerifier verifier,
             String endpoint
     ) {
-        return verifier.issueChallenge(endpoint).join();
+        return verifier.issueChallenge(endpoint);
     }
 
-    public static AttestationResponse verifyWithCallbacks(
+    public static CompletableFuture<AttestationResponse> verify(
             JavaAttestationVerifier verifier,
             AttestationProof proof
     ) {
         return verifier.verifyAttestation(proof, new JavaAttestationVerifier.Callbacks() {
-            @Override public void onChallengeValidated(AttestationChallenge challenge, AttestationProof receivedProof) { }
-            @Override public String onPreAttestationError(PreAttestationError error) { return null; }
-            @Override public String onAttestationError(AttestationResult.Error error, WardenDebugAttestationStatement debugInfo) { return null; }
-            @Override public void onAttestationSuccess(AttestationResult.Verified verified, CryptoPublicKey publicKey) { }
-            @Override public AttestationResponse.Failure additionalVerifications(AttestationChallenge challenge, AttestationProof receivedProof, AttestationResult.Verified verified) { return null; }
-            @Override public java.util.List<X509Certificate> certificateIssuer(AttestationResult.Verified verified, AttestationProof receivedProof) { return java.util.Collections.emptyList(); }
-        }).join();
+            @Override
+            public void onChallengeValidated(
+                    /*(3)!*/AttestationChallenge challenge,
+                    AttestationProof receivedProof
+            ) {
+                // Log or record the validated challenge here.
+            }
+
+            @Override
+            public String onPreAttestationError(PreAttestationError error) {
+                return null;
+            }
+
+            @Override
+            public String onAttestationError(
+                    AttestationResult.Error error,
+                    WardenDebugAttestationStatement debugInfo
+            ) {
+                return null;
+            }
+
+            @Override
+            public void onAttestationSuccess(
+                    /*(4)!*/AttestationResult.Verified verified,
+                    CryptoPublicKey publicKey
+            ) {
+                // Record successful attestation metrics here.
+            }
+
+            @Override
+            public AttestationResponse.Failure additionalVerifications(
+                    AttestationChallenge challenge,
+                    AttestationProof receivedProof,
+                    AttestationResult.Verified verified
+            ) {
+                /*(5)!*/return null;
+            }
+
+            @Override
+            public List<X509Certificate> certificateIssuer(
+                    AttestationResult.Verified verified,
+                    AttestationProof receivedProof
+            ) {
+                // Replace with the certificate chain issued by the application.
+                /*(6)!*/return Collections.emptyList();
+            }
+        });
     }
+
+    public static void applicationFlow(AttestationProof proof) throws AttestationException.Configuration {
+        /*(7)!*/JavaAttestationVerifier verifier = newVerifier();
+        issueChallenge(verifier, "https://example.test/attest").thenAccept(challenge -> {
+            // Send challenge to the mobile client, then receive its proof over HTTPS.
+        });
+        verify(verifier, proof).thenAccept(response -> {
+            // Return the response to the client or handle the failure.
+        });
+    }
+    // --8<-- [end:java-example-verifier]
 }

--- a/supreme/verifier/src/jvmTest/java/examples/javaapi/SupremeVerifierJavaApi.java
+++ b/supreme/verifier/src/jvmTest/java/examples/javaapi/SupremeVerifierJavaApi.java
@@ -1,0 +1,38 @@
+package examples.javaapi;
+
+import at.asitplus.attestation.supreme.AttestationChallenge;
+import at.asitplus.attestation.supreme.AttestationProof;
+import at.asitplus.attestation.supreme.AttestationResponse;
+import at.asitplus.attestation.supreme.JavaAttestationVerifier;
+import at.asitplus.attestation.AttestationResult;
+import at.asitplus.attestation.WardenDebugAttestationStatement;
+import at.asitplus.attestation.supreme.PreAttestationError;
+import at.asitplus.signum.indispensable.CryptoPublicKey;
+import at.asitplus.signum.indispensable.pki.X509Certificate;
+
+/** Java usage of the Java-friendly AttestationVerifier adapter. */
+public final class SupremeVerifierJavaApi {
+    private SupremeVerifierJavaApi() {
+    }
+
+    public static AttestationChallenge issueChallenge(
+            JavaAttestationVerifier verifier,
+            String endpoint
+    ) {
+        return verifier.issueChallenge(endpoint).join();
+    }
+
+    public static AttestationResponse verifyWithCallbacks(
+            JavaAttestationVerifier verifier,
+            AttestationProof proof
+    ) {
+        return verifier.verifyAttestation(proof, new JavaAttestationVerifier.Callbacks() {
+            @Override public void onChallengeValidated(AttestationChallenge challenge, AttestationProof receivedProof) { }
+            @Override public String onPreAttestationError(PreAttestationError error) { return null; }
+            @Override public String onAttestationError(AttestationResult.Error error, WardenDebugAttestationStatement debugInfo) { return null; }
+            @Override public void onAttestationSuccess(AttestationResult.Verified verified, CryptoPublicKey publicKey) { }
+            @Override public AttestationResponse.Failure additionalVerifications(AttestationChallenge challenge, AttestationProof receivedProof, AttestationResult.Verified verified) { return null; }
+            @Override public java.util.List<X509Certificate> certificateIssuer(AttestationResult.Verified verified, AttestationProof receivedProof) { return java.util.Collections.emptyList(); }
+        }).join();
+    }
+}

--- a/supreme/verifier/src/jvmTest/kotlin/SupremeConfigurationTimeSourceSerializationTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/SupremeConfigurationTimeSourceSerializationTest.kt
@@ -1,0 +1,32 @@
+package at.asitplus.attestation.supreme
+
+import at.asitplus.attestation.IosAttestationConfiguration
+import at.asitplus.testballoon.matrix.matrixSuite
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+private val iosConfiguration = IosAttestationConfiguration(
+    IosAttestationConfiguration.AppData(
+        teamIdentifier = "9CYHJNG644",
+        bundleIdentifier = "at.asitplus.attestation-client",
+    ),
+)
+
+val SupremeConfigurationSerializationTest by matrixSuite {
+    data(
+        "clock implementations",
+        listOf(
+            "system" to SupremeConfiguration.Clock.System,
+            "fixed" to SupremeConfiguration.Clock.Fixed(Instant.parse("2025-01-10T12:34:56.789Z")),
+        ),
+        nameFn = { _, (name) -> name },
+    ) test { (_, clock) ->
+        val configuration = SupremeConfiguration(
+            ios = iosConfiguration,
+            clock = clock,
+        )
+
+        SupremeConfiguration.fromJsonString(configuration.toJsonString()) shouldBe configuration
+        SupremeConfiguration.fromYamlString(configuration.toYamlString()) shouldBe configuration
+    }
+}

--- a/supreme/verifier/src/jvmTest/kotlin/SupremeVerifierJavaApiTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/SupremeVerifierJavaApiTest.kt
@@ -1,38 +1,199 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package at.asitplus.attestation.supreme
 
 import at.asitplus.attestation.supreme.AttestationProof.Hashed
+import at.asitplus.attestation.supreme.AttestationProof.Signed
 import at.asitplus.signum.indispensable.pki.TbsCertificationRequest
+import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.signum.indispensable.toCryptoPublicKey
 import at.asitplus.testballoon.matrix.ExecutionMode
+import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixConfig
 import at.asitplus.testballoon.matrix.matrixSuite
+import examples.javaapi.JavaAttestationVerifierTestApi.Harness
+import examples.javaapi.JavaAttestationVerifierTestApi.RecordingCallbacks
 import examples.javaapi.SupremeVerifierJavaApi
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.Base64
+import java.util.Date
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+private data class JavaProofFixture(
+    val challenge: AttestationChallenge,
+    val proof: Signed,
+    val certificateChain: List<X509Certificate>,
+)
+
+private fun AndroidFixture.javaHarness(
+    packageName: String = fakeAndroidPackage,
+): Harness = Harness(
+    SupremeConfiguration(
+        android = trustedConfig(packageName = packageName),
+        clock = SupremeConfiguration.Clock.Fixed(fixedClock.now()),
+        verificationTimeOffset = Duration.ZERO,
+    ),
+)
+
+private fun AndroidFixture.issueJavaProof(harness: Harness): JavaProofFixture {
+    val challenge = harness.issueChallenge(attestationEndpoint).get(10, TimeUnit.SECONDS)
+    val attestation = createFakeAndroidAttestationWithRoots(
+        challenge = challenge.nonce,
+        packageName = fakeAndroidPackage,
+        signatureDigest = fakeAndroidSignerDigest,
+        creationTime = Date(fixedClock.now().toEpochMilliseconds()),
+        deviceLocked = true,
+        verifiedBootState = BootState.VERIFIED,
+        rootKeyPair = fake.rootKeyPair,
+        rootCertificate = fake.rootCertificate,
+        intermediateKeyPair = fake.intermediateKeyPair,
+        intermediateCertificate = fake.intermediateCertificate,
+    )
+    return JavaProofFixture(
+        challenge = challenge,
+        proof = Signed(createCsr(challenge, attestation.attestationJson(), attestation.leafKeyPair)),
+        certificateChain = attestation.certificateChain.toSignumChain(),
+    )
+}
 
 val SupremeVerifierJavaApiTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
 
-    val javaApiVerifier = SupremeVerifierJavaApi.newVerifier()
+    val documentedVerifier = SupremeVerifierJavaApi.newVerifier()
 
-
-    "issueChallenge" {
-        val challenge = SupremeVerifierJavaApi.issueChallenge(javaApiVerifier, "https://example.test/attest").join()
-        challenge.attestationEndpoint shouldBe "https://example.test/attest"
+    "documented challenge API" {
+        val future = SupremeVerifierJavaApi.issueChallenge(documentedVerifier, "https://example.test/attest")
+        future.shouldBeInstanceOf<CompletableFuture<AttestationChallenge>>()
+        future.get(10, TimeUnit.SECONDS).attestationEndpoint shouldBe "https://example.test/attest"
     }
 
-    "verifyWithCallbacks" {
-        // A structurally incomplete proof is sufficient to exercise the Java callback boundary.
+    "documented malformed proof API" {
         SupremeVerifierJavaApi.verify(
-            javaApiVerifier, Hashed(
+            documentedVerifier,
+            Hashed(
                 TbsCertificationRequest(
                     subjectName = emptyList(),
                     publicKey = generateRsaKeyPair(1024).public.toCryptoPublicKey().getOrThrow(),
                     attributes = emptyList(),
                 ),
-            )
-        ).join().shouldBeInstanceOf<AttestationResponse.Failure>()
+            ),
+        ).get(10, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<AttestationResponse.Failure>()
             .kind shouldBe AttestationResponse.Failure.Type.CONTENT
     }
 
+    fixture { generateAndroidFixture() } - {
+        test("successful verification preserves every Java callback argument and order") { fixture ->
+            val harness = fixture.javaHarness()
+            val issued = fixture.issueJavaProof(harness)
+            val callbacks = RecordingCallbacks().apply {
+                setCertificates(issued.certificateChain)
+            }
 
+            val response = harness.verify(issued.proof, callbacks).get(10, TimeUnit.SECONDS)
+
+            response.shouldBeInstanceOf<AttestationResponse.Success>()
+                .certificateChain shouldBe issued.certificateChain
+            callbacks.calls shouldBe listOf("challenge", "additional", "issuer", "success")
+            callbacks.validatedChallenge shouldBe issued.challenge
+            callbacks.validatedProof shouldBe issued.proof
+            callbacks.additionalChallenge shouldBe issued.challenge
+            callbacks.additionalProof shouldBe issued.proof
+            callbacks.issuerProof shouldBe issued.proof
+            callbacks.issuerVerified shouldBe callbacks.additionalVerified
+            callbacks.successfulVerified shouldBe callbacks.additionalVerified
+            callbacks.successfulPublicKey shouldBe issued.proof.data.tbsCsr.publicKey
+            callbacks.preAttestationError shouldBe null
+            callbacks.attestationError shouldBe null
+        }
+
+        test("Java additional verification can reject and skips issuer and success callbacks") { fixture ->
+            val harness = fixture.javaHarness()
+            val issued = fixture.issueJavaProof(harness)
+            val rejection = AttestationResponse.Failure(
+                AttestationResponse.Failure.Type.TRUST,
+                "rejected by Java policy",
+            )
+            val callbacks = RecordingCallbacks().apply {
+                setAdditionalFailure(rejection)
+                setCertificates(issued.certificateChain)
+            }
+
+            val response = harness.verify(issued.proof, callbacks).get(10, TimeUnit.SECONDS)
+
+            response shouldBe rejection
+            callbacks.calls shouldBe listOf("challenge", "additional")
+            callbacks.additionalChallenge shouldBe issued.challenge
+            callbacks.additionalProof shouldBe issued.proof
+            callbacks.issuerProof shouldBe null
+            callbacks.successfulVerified shouldBe null
+        }
+
+        test("attestation failures reach the Java error callback with debug information") { fixture ->
+            val harness = fixture.javaHarness(packageName = "com.example.not-the-attested-app")
+            val issued = fixture.issueJavaProof(harness)
+            val callbacks = RecordingCallbacks().apply {
+                setAttestationErrorExplanation("Java saw the policy failure")
+            }
+
+            val response = harness.verify(issued.proof, callbacks).get(10, TimeUnit.SECONDS)
+
+            response.shouldBeInstanceOf<AttestationResponse.Failure>().also {
+                it.kind shouldBe AttestationResponse.Failure.Type.CONTENT
+                it.explanation shouldBe "Java saw the policy failure"
+            }
+            callbacks.calls shouldBe listOf("challenge", "attestation-error")
+            callbacks.attestationError.shouldBeInstanceOf<at.asitplus.attestation.AttestationResult.Error>()
+            callbacks.debugInfo.challenge?.contentEquals(issued.challenge.nonce) shouldBe true
+            callbacks.preAttestationError shouldBe null
+        }
+
+        test("issuer exceptions map to an internal response and invoke the Java pre-error callback") { fixture ->
+            val harness = fixture.javaHarness()
+            val issued = fixture.issueJavaProof(harness)
+            val callbacks = RecordingCallbacks().apply {
+                setIssuerException(IllegalStateException("issuer exploded"))
+                setPreErrorExplanation("Java issuer failed")
+            }
+
+            val response = harness.verify(issued.proof, callbacks).get(10, TimeUnit.SECONDS)
+
+            response.shouldBeInstanceOf<AttestationResponse.Failure>().also {
+                it.kind shouldBe AttestationResponse.Failure.Type.INTERNAL
+                it.explanation shouldBe "Java issuer failed"
+            }
+            callbacks.calls shouldBe listOf("challenge", "additional", "issuer", "pre-error")
+            callbacks.preAttestationError.shouldBeInstanceOf<PreAttestationError.OperationalError>()
+            callbacks.successfulVerified shouldBe null
+        }
+
+        test("Java observation callback exceptions remain side-effect only") { fixture ->
+            val harness = fixture.javaHarness()
+            val issued = fixture.issueJavaProof(harness)
+            val callbacks = RecordingCallbacks().apply {
+                setCertificates(issued.certificateChain)
+                setThrowOnChallengeValidated(true)
+                setThrowOnAttestationSuccess(true)
+            }
+
+            harness.verify(issued.proof, callbacks).get(10, TimeUnit.SECONDS)
+                .shouldBeInstanceOf<AttestationResponse.Success>()
+            callbacks.calls shouldBe listOf("challenge", "additional", "issuer", "success")
+        }
+
+        test("concurrent Java challenge futures complete with distinct nonces") { fixture ->
+            val harness = fixture.javaHarness()
+            val futures = List(32) { harness.issueChallenge("$attestationEndpoint/$it") }
+
+            CompletableFuture.allOf(*futures.toTypedArray()).get(10, TimeUnit.SECONDS)
+            val challenges = futures.map { it.join() }
+
+            challenges shouldHaveSize 32
+            challenges.map { it.attestationEndpoint }.toSet() shouldHaveSize 32
+            challenges.map { Base64.getEncoder().encodeToString(it.nonce) }.toSet() shouldHaveSize 32
+        }
+    }
 }

--- a/supreme/verifier/src/jvmTest/kotlin/SupremeVerifierJavaApiTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/SupremeVerifierJavaApiTest.kt
@@ -1,0 +1,49 @@
+package at.asitplus.attestation.supreme
+
+import at.asitplus.attestation.IosAttestationConfiguration
+import at.asitplus.attestation.supreme.AttestationProof.Hashed
+import at.asitplus.attestation.supreme.SupremeConfiguration.Clock.Fixed
+import at.asitplus.signum.indispensable.pki.TbsCertificationRequest
+import at.asitplus.signum.indispensable.toCryptoPublicKey
+import at.asitplus.testballoon.matrix.ExecutionMode
+import at.asitplus.testballoon.matrix.matrixConfig
+import at.asitplus.testballoon.matrix.matrixSuite
+import examples.javaapi.SupremeVerifierJavaApi
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.time.Instant
+
+val SupremeVerifierJavaApiTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
+
+    val javaApiVerifier = JavaAttestationVerifier(
+        SupremeConfiguration(
+            ios = IosAttestationConfiguration(
+                IosAttestationConfiguration.AppData("1234567890", "example.app"),
+            ),
+            clock = Fixed(Instant.parse("2025-01-10T12:34:56Z")),
+        ),
+    )
+
+
+    "issueChallenge" {
+        val challenge = SupremeVerifierJavaApi.issueChallenge(javaApiVerifier, "https://example.test/attest")
+        challenge.attestationEndpoint shouldBe "https://example.test/attest"
+    }
+
+    "verifyWithCallbacks" {
+        // A null proof is sufficient here: the call crosses the Java/Kotlin suspend boundary,
+        // and the verifier maps the resulting operational failure to a response.
+        SupremeVerifierJavaApi.verifyWithCallbacks(
+            javaApiVerifier, Hashed(
+                TbsCertificationRequest(
+                    subjectName = emptyList(),
+                    publicKey = generateRsaKeyPair(1024).public.toCryptoPublicKey().getOrThrow(),
+                    attributes = emptyList(),
+                ),
+            )
+        ).shouldBeInstanceOf<AttestationResponse.Failure>()
+            .kind shouldBe AttestationResponse.Failure.Type.CONTENT
+    }
+
+
+}

--- a/supreme/verifier/src/jvmTest/kotlin/SupremeVerifierJavaApiTest.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/SupremeVerifierJavaApiTest.kt
@@ -1,8 +1,6 @@
 package at.asitplus.attestation.supreme
 
-import at.asitplus.attestation.IosAttestationConfiguration
 import at.asitplus.attestation.supreme.AttestationProof.Hashed
-import at.asitplus.attestation.supreme.SupremeConfiguration.Clock.Fixed
 import at.asitplus.signum.indispensable.pki.TbsCertificationRequest
 import at.asitplus.signum.indispensable.toCryptoPublicKey
 import at.asitplus.testballoon.matrix.ExecutionMode
@@ -11,29 +9,20 @@ import at.asitplus.testballoon.matrix.matrixSuite
 import examples.javaapi.SupremeVerifierJavaApi
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.time.Instant
 
 val SupremeVerifierJavaApiTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
 
-    val javaApiVerifier = JavaAttestationVerifier(
-        SupremeConfiguration(
-            ios = IosAttestationConfiguration(
-                IosAttestationConfiguration.AppData("1234567890", "example.app"),
-            ),
-            clock = Fixed(Instant.parse("2025-01-10T12:34:56Z")),
-        ),
-    )
+    val javaApiVerifier = SupremeVerifierJavaApi.newVerifier()
 
 
     "issueChallenge" {
-        val challenge = SupremeVerifierJavaApi.issueChallenge(javaApiVerifier, "https://example.test/attest")
+        val challenge = SupremeVerifierJavaApi.issueChallenge(javaApiVerifier, "https://example.test/attest").join()
         challenge.attestationEndpoint shouldBe "https://example.test/attest"
     }
 
     "verifyWithCallbacks" {
-        // A null proof is sufficient here: the call crosses the Java/Kotlin suspend boundary,
-        // and the verifier maps the resulting operational failure to a response.
-        SupremeVerifierJavaApi.verifyWithCallbacks(
+        // A structurally incomplete proof is sufficient to exercise the Java callback boundary.
+        SupremeVerifierJavaApi.verify(
             javaApiVerifier, Hashed(
                 TbsCertificationRequest(
                     subjectName = emptyList(),
@@ -41,7 +30,7 @@ val SupremeVerifierJavaApiTest by matrixSuite(matrixConfig { execution = Executi
                     attributes = emptyList(),
                 ),
             )
-        ).shouldBeInstanceOf<AttestationResponse.Failure>()
+        ).join().shouldBeInstanceOf<AttestationResponse.Failure>()
             .kind shouldBe AttestationResponse.Failure.Type.CONTENT
     }
 

--- a/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-config.kt
+++ b/supreme/verifier/src/jvmTest/kotlin/examples/Readme-Verifier-config.kt
@@ -32,33 +32,34 @@ val customerAttributesOID = ObjectIdentifier("2.25.30419858255939885837023545453
 val configuration = SupremeConfiguration(
  /*(1)!*/android = makoto.androidAttestationConfiguration!!,
     ios = makoto.iosAttestationConfiguration!!,
- /*(2)!*/attestationProofOID = serviceSpecificOID, //override default
- /*(3)!*/genericDeviceNameOID = null, //WardenDefaults.OIDs.DEVICE_NAME by default
- /*(4)!*/defaultKeyConstraints = KeyConstraints(
+ /*(2)!*/clock = SupremeConfiguration.Clock.System,
+ /*(3)!*/attestationProofOID = serviceSpecificOID, //override default
+ /*(4)!*/genericDeviceNameOID = null, //WardenDefaults.OIDs.DEVICE_NAME by default
+ /*(5)!*/defaultKeyConstraints = KeyConstraints(
         algorithmParameters = AlgorithmParameters.EC(
             curve = ECCurve.SECP_256_R_1,
             digests = setOf(ECCurve.SECP_256_R_1.nativeDigest),
             allowKeyAgreement = false //DEFAULT
         ),
- /*(5)!*/keyProtection = KeyProtection(
+ /*(6)!*/keyProtection = KeyProtection(
             timeout = 30.seconds,
             deviceLock = false,
             biometry = true,
             allowNewBiometricFactors = false,
         )
     ),
- /*(6)!*/toBeAttestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
+ /*(7)!*/toBeAttestedAttributes = AttestationChallenge.CertificationRequestAttributeAttestationDescriptor(
         customerAttributesOID,
         listOf(
             AttestationChallenge.AttributeAttestationDescriptor("accountId", PrimitiveType.STRING),
             AttestationChallenge.AttributeAttestationDescriptor("riskScore", PrimitiveType.INT, required = false),
         ),
     ),
- /*(7)!*/dataAuth = DataAuthentication.Hash(Digest.SHA256),
+ /*(8)!*/dataAuth = DataAuthentication.Hash(Digest.SHA256),
 )
 
 val verifier = AttestationVerifier(
     configuration,
- /*(8)!*/nonceGenerator = suspend { CryptoRand.nextBytes(ByteArray(/*(9)!*/128)) },
-) {/*(10)!*/clock, offset -> redisBacked }
+ /*(9)!*/nonceGenerator = suspend { CryptoRand.nextBytes(ByteArray(/*(10)!*/128)) },
+) {/*(11)!*/clock, offset -> redisBacked }
 // --8<-- [end:verifier-config-supreme]


### PR DESCRIPTION
* Add Fixed time source shorthand in `SupremeConfiguration`
* More Java-Friendliness all over the place (see docs/integration/java)
    * Mark Java-Only APIs `internal` and use `@JvmName` to hide them from the public Kotlin API   